### PR TITLE
MAKE-395 Modify Grip composers/senders to allow all message info to specified in composers

### DIFF
--- a/message/composer_test.go
+++ b/message/composer_test.go
@@ -55,6 +55,8 @@ func TestPopulatedMessageComposerConstructors(t *testing.T) {
 			URL:         "https://example.com",
 			Description: testMsg,
 		}): fmt.Sprintf("mongodb/grip@master tests error: %s (https://example.com)", testMsg),
+		NewJIRACommentMessage(level.Error, "ABC-123", testMsg): testMsg,
+		NewSlackMessage(level.Error, "@someone", testMsg, nil): fmt.Sprintf("@someone: %s", testMsg),
 	}
 
 	for msg, output := range cases {
@@ -81,6 +83,8 @@ func TestPopulatedMessageComposerConstructors(t *testing.T) {
 		// check message annotation functionality
 		switch msg.(type) {
 		case *GroupComposer:
+			continue
+		case *slackMessage:
 			continue
 		default:
 			assert.NoError(msg.Annotate("k1", "foo"), "%T", msg)
@@ -118,6 +122,8 @@ func TestUnpopulatedMessageComposers(t *testing.T) {
 		Whenln(false, "", ""),
 		NewGithubStatusMessage(level.Error, "", GithubState(""), "", ""),
 		NewGithubStatusMessageWithRepo(level.Error, GithubStatus{}),
+		NewJIRACommentMessage(level.Error, "", ""),
+		NewSlackMessage(level.Error, "", "", nil),
 	}
 
 	for idx, msg := range cases {

--- a/message/composer_test.go
+++ b/message/composer_test.go
@@ -44,6 +44,17 @@ func TestPopulatedMessageComposerConstructors(t *testing.T) {
 		When(true, testMsg):                                                    testMsg,
 		Whenf(true, testMsg):                                                   testMsg,
 		Whenln(true, testMsg):                                                  testMsg,
+		NewGithubStatusMessage(level.Error, "tests", GithubStateError, "https://example.com", testMsg): fmt.Sprintf("tests error: %s (https://example.com)", testMsg),
+		NewGithubStatusMessageWithRepo(level.Error, GithubStatus{
+			Owner: "mongodb",
+			Repo:  "grip",
+			Ref:   "master",
+
+			Context:     "tests",
+			State:       GithubStateError,
+			URL:         "https://example.com",
+			Description: testMsg,
+		}): fmt.Sprintf("mongodb/grip@master tests error: %s (https://example.com)", testMsg),
 	}
 
 	for msg, output := range cases {
@@ -105,6 +116,8 @@ func TestUnpopulatedMessageComposers(t *testing.T) {
 		When(false, ""),
 		Whenf(false, "", ""),
 		Whenln(false, "", ""),
+		NewGithubStatusMessage(level.Error, "", GithubState(""), "", ""),
+		NewGithubStatusMessageWithRepo(level.Error, GithubStatus{}),
 	}
 
 	for idx, msg := range cases {

--- a/message/github_status.go
+++ b/message/github_status.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/google/go-github/github"
 	"github.com/mongodb/grip/level"
 )
 
@@ -20,23 +19,69 @@ const (
 	GithubStateFailure = GithubState("failure")
 )
 
-type githubStatus struct {
+// GithubStatus is a message to be posted to Github's Status API
+type GithubStatus struct {
+	Owner string `bson:"owner,omitempty" json:"owner,omitempty" yaml:"owner,omitempty"`
+	Repo  string `bson:"repo,omitempty" json:"repo,omitempty" yaml:"repo,omitempty"`
+	Ref   string `bson:"ref,omitempty" json:"ref,omitempty" yaml:"ref,omitempty"`
+
 	Context     string      `bson:"context" json:"context" yaml:"context"`
 	State       GithubState `bson:"state" json:"state" yaml:"state"`
 	URL         string      `bson:"url" json:"url" yaml:"url"`
 	Description string      `bson:"description" json:"description" yaml:"description"`
+}
+
+// Valid returns true if the message is well formed
+func (p *GithubStatus) Valid() bool {
+	// owner, repo and ref must be empty or must be set
+	ownerEmpty := len(p.Owner) == 0
+	repoEmpty := len(p.Repo) == 0
+	refLen := len(p.Ref) == 0
+	if ownerEmpty != repoEmpty || repoEmpty != refLen {
+		return false
+	}
+
+	switch p.State {
+	case GithubStatePending, GithubStateSuccess, GithubStateError, GithubStateFailure:
+	default:
+		return false
+	}
+
+	_, err := url.Parse(p.URL)
+	if err != nil || len(p.Context) == 0 {
+		return false
+	}
+
+	return true
+}
+
+type githubStatus struct {
+	raw GithubStatus
 
 	Base `bson:"metadata" json:"metadata" yaml:"metadata"`
 }
 
+// NewGithubStatusWithRepo creates a composer for sending payloads to the Github Status
+// API, with the repository and ref stored in the composer
+func NewGithubStatusWithRepo(p level.Priority, status GithubStatus) Composer {
+	s := &githubStatus{
+		raw: status,
+	}
+	_ = s.SetPriority(p)
+
+	return s
+}
+
 // NewGithubStatus creates a composer for sending payloads to the Github Status
-// API
+// API.
 func NewGithubStatus(p level.Priority, context string, state GithubState, URL, description string) Composer {
 	s := &githubStatus{
-		Context:     context,
-		State:       state,
-		URL:         URL,
-		Description: description,
+		raw: GithubStatus{
+			Context:     context,
+			State:       state,
+			URL:         URL,
+			Description: description,
+		},
 	}
 	_ = s.SetPriority(p)
 
@@ -44,38 +89,22 @@ func NewGithubStatus(p level.Priority, context string, state GithubState, URL, d
 }
 
 func (c *githubStatus) Loggable() bool {
-	_, err := url.Parse(c.URL)
-	if err != nil || len(c.Context) == 0 {
-		return false
-	}
-
-	switch c.State {
-	case GithubStatePending, GithubStateSuccess, GithubStateError, GithubStateFailure:
-	default:
-		return false
-	}
-
-	return true
+	return c.raw.Valid()
 }
 
 func (c *githubStatus) String() string {
-	if len(c.Description) == 0 {
+	base := c.raw.Ref
+	if len(c.raw.Owner) > 0 {
+		base = fmt.Sprintf("%s/%s@%s", c.raw.Owner, c.raw.Repo, c.raw.Ref)
+	}
+	if len(c.raw.Description) == 0 {
 		// looks like: evergreen failed (https://evergreen.mongodb.com)
-		return fmt.Sprintf("%s %s (%s)", c.Context, string(c.State), c.URL)
+		return base + fmt.Sprintf("%s %s (%s)", c.raw.Context, string(c.raw.State), c.raw.URL)
 	}
 	// looks like: evergreen failed: 1 task failed (https://evergreen.mongodb.com)
-	return fmt.Sprintf("%s %s: %s (%s)", c.Context, string(c.State), c.Description, c.URL)
+	return base + fmt.Sprintf("%s %s: %s (%s)", c.raw.Context, string(c.raw.State), c.raw.Description, c.raw.URL)
 }
 
 func (c *githubStatus) Raw() interface{} {
-	s := &github.RepoStatus{
-		Context: github.String(c.Context),
-		State:   github.String(string(c.State)),
-		URL:     github.String(c.URL),
-	}
-	if len(c.Description) > 0 {
-		s.Description = github.String(c.Description)
-	}
-
-	return s
+	return &c.raw
 }

--- a/message/github_status.go
+++ b/message/github_status.go
@@ -64,18 +64,33 @@ type githubStatusMessage struct {
 // NewGithubStatusMessageWithRepo creates a composer for sending payloads to the Github Status
 // API, with the repository and ref stored in the composer
 func NewGithubStatusMessageWithRepo(p level.Priority, status GithubStatus) Composer {
-	s := &githubStatusMessage{
-		raw: status,
-	}
+	s := MakeGithubStatusMessageWithRepo(status)
 	_ = s.SetPriority(p)
 
 	return s
 }
 
+// MakeGithubStatusMessageWithRepo creates a composer for sending payloads to the Github Status
+// API, with the repository and ref stored in the composer
+func MakeGithubStatusMessageWithRepo(status GithubStatus) Composer {
+	return &githubStatusMessage{
+		raw: status,
+	}
+}
+
 // NewGithubStatusMessage creates a composer for sending payloads to the Github Status
 // API.
 func NewGithubStatusMessage(p level.Priority, context string, state GithubState, URL, description string) Composer {
-	s := &githubStatusMessage{
+	s := MakeGithubStatusMessage(context, state, URL, description)
+	_ = s.SetPriority(p)
+
+	return s
+}
+
+// MakeGithubStatusMessage creates a composer for sending payloads to the Github Status
+// API without setting a priority
+func MakeGithubStatusMessage(context string, state GithubState, URL, description string) Composer {
+	return &githubStatusMessage{
 		raw: GithubStatus{
 			Context:     context,
 			State:       state,
@@ -83,9 +98,6 @@ func NewGithubStatusMessage(p level.Priority, context string, state GithubState,
 			Description: description,
 		},
 	}
-	_ = s.SetPriority(p)
-
-	return s
 }
 
 func (c *githubStatusMessage) Loggable() bool {

--- a/message/github_status.go
+++ b/message/github_status.go
@@ -95,7 +95,7 @@ func (c *githubStatusMessage) Loggable() bool {
 func (c *githubStatusMessage) String() string {
 	base := c.raw.Ref
 	if len(c.raw.Owner) > 0 {
-		base = fmt.Sprintf("%s/%s@%s", c.raw.Owner, c.raw.Repo, c.raw.Ref)
+		base = fmt.Sprintf("%s/%s@%s ", c.raw.Owner, c.raw.Repo, c.raw.Ref)
 	}
 	if len(c.raw.Description) == 0 {
 		// looks like: evergreen failed (https://evergreen.mongodb.com)

--- a/message/github_status.go
+++ b/message/github_status.go
@@ -55,16 +55,16 @@ func (p *GithubStatus) Valid() bool {
 	return true
 }
 
-type githubStatus struct {
+type githubStatusMessage struct {
 	raw GithubStatus
 
 	Base `bson:"metadata" json:"metadata" yaml:"metadata"`
 }
 
-// NewGithubStatusWithRepo creates a composer for sending payloads to the Github Status
+// NewGithubStatusMessageWithRepo creates a composer for sending payloads to the Github Status
 // API, with the repository and ref stored in the composer
-func NewGithubStatusWithRepo(p level.Priority, status GithubStatus) Composer {
-	s := &githubStatus{
+func NewGithubStatusMessageWithRepo(p level.Priority, status GithubStatus) Composer {
+	s := &githubStatusMessage{
 		raw: status,
 	}
 	_ = s.SetPriority(p)
@@ -72,10 +72,10 @@ func NewGithubStatusWithRepo(p level.Priority, status GithubStatus) Composer {
 	return s
 }
 
-// NewGithubStatus creates a composer for sending payloads to the Github Status
+// NewGithubStatusMessage creates a composer for sending payloads to the Github Status
 // API.
-func NewGithubStatus(p level.Priority, context string, state GithubState, URL, description string) Composer {
-	s := &githubStatus{
+func NewGithubStatusMessage(p level.Priority, context string, state GithubState, URL, description string) Composer {
+	s := &githubStatusMessage{
 		raw: GithubStatus{
 			Context:     context,
 			State:       state,
@@ -88,11 +88,11 @@ func NewGithubStatus(p level.Priority, context string, state GithubState, URL, d
 	return s
 }
 
-func (c *githubStatus) Loggable() bool {
+func (c *githubStatusMessage) Loggable() bool {
 	return c.raw.Valid()
 }
 
-func (c *githubStatus) String() string {
+func (c *githubStatusMessage) String() string {
 	base := c.raw.Ref
 	if len(c.raw.Owner) > 0 {
 		base = fmt.Sprintf("%s/%s@%s", c.raw.Owner, c.raw.Repo, c.raw.Ref)
@@ -105,6 +105,6 @@ func (c *githubStatus) String() string {
 	return base + fmt.Sprintf("%s %s: %s (%s)", c.raw.Context, string(c.raw.State), c.raw.Description, c.raw.URL)
 }
 
-func (c *githubStatus) Raw() interface{} {
+func (c *githubStatusMessage) Raw() interface{} {
 	return &c.raw
 }

--- a/message/github_status_test.go
+++ b/message/github_status_test.go
@@ -10,7 +10,7 @@ import (
 func TestGithubStatus(t *testing.T) {
 	assert := assert.New(t) //nolint: vetshadow
 
-	c := NewGithubStatus(level.Info, "example", GithubStatePending, "https://example.com/hi", "description")
+	c := NewGithubStatusMessage(level.Info, "example", GithubStatePending, "https://example.com/hi", "description")
 	assert.NotNil(c)
 	assert.True(c.Loggable())
 
@@ -30,11 +30,11 @@ func TestGithubStatus(t *testing.T) {
 func TestGithubStatusInvalidStatusesAreNotLoggable(t *testing.T) {
 	assert := assert.New(t) //nolint: vetshadow
 
-	c := NewGithubStatus(level.Info, "", GithubStatePending, "https://example.com/hi", "description")
+	c := NewGithubStatusMessage(level.Info, "", GithubStatePending, "https://example.com/hi", "description")
 	assert.False(c.Loggable())
-	c = NewGithubStatus(level.Info, "example", "nope", "https://example.com/hi", "description")
+	c = NewGithubStatusMessage(level.Info, "example", "nope", "https://example.com/hi", "description")
 	assert.False(c.Loggable())
-	c = NewGithubStatus(level.Info, "example", GithubStatePending, ":foo", "description")
+	c = NewGithubStatusMessage(level.Info, "example", GithubStatePending, ":foo", "description")
 	assert.False(c.Loggable())
 
 	p := GithubStatus{
@@ -46,16 +46,16 @@ func TestGithubStatusInvalidStatusesAreNotLoggable(t *testing.T) {
 		URL:         "https://example.com/hi",
 		Description: "description",
 	}
-	c = NewGithubStatusWithRepo(level.Info, p)
+	c = NewGithubStatusMessageWithRepo(level.Info, p)
 	assert.False(c.Loggable())
 
 	p.Owner = "mongodb"
 	p.Repo = ""
-	c = NewGithubStatusWithRepo(level.Info, p)
+	c = NewGithubStatusMessageWithRepo(level.Info, p)
 	assert.False(c.Loggable())
 
 	p.Repo = "grip"
 	p.Ref = ""
-	c = NewGithubStatusWithRepo(level.Info, p)
+	c = NewGithubStatusMessageWithRepo(level.Info, p)
 	assert.False(c.Loggable())
 }

--- a/message/jira_comment.go
+++ b/message/jira_comment.go
@@ -20,16 +20,22 @@ type JIRAComment struct {
 // to a single JIRA issue. This composer will override the issue set in the
 // JIRA sender
 func NewJIRACommentMessage(p level.Priority, issueID, body string) Composer {
-	s := &jiraComment{
+	s := MakeJIRACommentMessage(issueID, body)
+	_ = s.SetPriority(p)
+
+	return s
+}
+
+// MakeJIRACommentMessage returns a self-contained composer for posting a comment
+// to a single JIRA issue. This composer will override the issue set in the
+// JIRA sender. The composer will not have a priority set
+func MakeJIRACommentMessage(issueID, body string) Composer {
+	return &jiraComment{
 		Payload: JIRAComment{
 			IssueID: issueID,
 			Body:    body,
 		},
 	}
-
-	_ = s.SetPriority(p)
-
-	return s
 }
 
 func (c *jiraComment) Loggable() bool {

--- a/message/jira_comment.go
+++ b/message/jira_comment.go
@@ -1,0 +1,45 @@
+package message
+
+import (
+	"github.com/mongodb/grip/level"
+)
+
+type jiraComment struct {
+	Payload JIRAComment `bson:"payload" json:"payload" yaml:"payload"`
+
+	Base `bson:"metadata" json:"metadata" yaml:"metadata"`
+}
+
+// JIRAComment represents a single comment to post to the given JIRA issue
+type JIRAComment struct {
+	IssueID string `bson:"issue_id,omitempty" json:"issue_id,omitempty" yaml:"issue_id,omitempty"`
+	Body    string `bson:"body" json:"body" yaml:"body"`
+}
+
+// NewJIRAComment returns a self-contained composer for posting a comment
+// to a single JIRA issue. This composer will override the issue set in the
+// JIRA sender
+func NewJIRAComment(p level.Priority, issueID, body string) Composer {
+	s := &jiraComment{
+		Payload: JIRAComment{
+			IssueID: issueID,
+			Body:    body,
+		},
+	}
+
+	_ = s.SetPriority(p)
+
+	return s
+}
+
+func (c *jiraComment) Loggable() bool {
+	return len(c.Payload.IssueID) > 0 && len(c.Payload.Body) > 0
+}
+
+func (c *jiraComment) String() string {
+	return c.Payload.Body
+}
+
+func (c *jiraComment) Raw() interface{} {
+	return &c.Payload
+}

--- a/message/jira_comment.go
+++ b/message/jira_comment.go
@@ -16,10 +16,10 @@ type JIRAComment struct {
 	Body    string `bson:"body" json:"body" yaml:"body"`
 }
 
-// NewJIRAComment returns a self-contained composer for posting a comment
+// NewJIRACommentMessage returns a self-contained composer for posting a comment
 // to a single JIRA issue. This composer will override the issue set in the
 // JIRA sender
-func NewJIRAComment(p level.Priority, issueID, body string) Composer {
+func NewJIRACommentMessage(p level.Priority, issueID, body string) Composer {
 	s := &jiraComment{
 		Payload: JIRAComment{
 			IssueID: issueID,

--- a/message/slack.go
+++ b/message/slack.go
@@ -1,0 +1,50 @@
+package message
+
+import (
+	"fmt"
+
+	"github.com/bluele/slack"
+	"github.com/mongodb/grip/level"
+)
+
+// Slack is a message to a Slack channel
+type Slack struct {
+	Target      string              `bson:"target,omitempty" json:"target,omitempty" yaml:"target,omitempty"`
+	Msg         string              `bson:"msg" json:"msg" yaml:"msg"`
+	Attachments []*slack.Attachment `bson:"attachments" json:"attachments" yaml:"attachments"`
+}
+
+type slackMessage struct {
+	raw Slack
+
+	Base `bson:"metadata" json:"metadata" yaml:"metadata"`
+}
+
+// NewSlackMessage creates a composer for messages to slack
+func NewSlackMessage(p level.Priority, target string, msg string, attachments []*slack.Attachment) Composer {
+	s := &slackMessage{
+		raw: Slack{
+			Target: target,
+			Msg:    msg,
+		},
+	}
+	if len(attachments) != 0 {
+		s.raw.Attachments = attachments
+	}
+
+	_ = s.SetPriority(p)
+
+	return s
+}
+
+func (c *slackMessage) Loggable() bool {
+	return len(c.raw.Msg) != 0
+}
+
+func (c *slackMessage) String() string {
+	return fmt.Sprintf("%s: %s", c.raw.Target, c.raw.Msg)
+}
+
+func (c *slackMessage) Raw() interface{} {
+	return &c.raw
+}

--- a/message/slack.go
+++ b/message/slack.go
@@ -1,17 +1,95 @@
 package message
 
 import (
+	"errors"
 	"fmt"
+	"reflect"
 
 	"github.com/bluele/slack"
 	"github.com/mongodb/grip/level"
 )
 
-// Slack is a message to a Slack channel
+// Slack is a message to a Slack channel or user
 type Slack struct {
 	Target      string              `bson:"target,omitempty" json:"target,omitempty" yaml:"target,omitempty"`
 	Msg         string              `bson:"msg" json:"msg" yaml:"msg"`
 	Attachments []*slack.Attachment `bson:"attachments" json:"attachments" yaml:"attachments"`
+}
+
+// SlackAttachment is a single attachment to a slack message.
+// This type is the same as bluele/slack.Attachment
+type SlackAttachment struct {
+	Color    string `bson:"color,omitempty" json:"color,omitempty" yaml:"color,omitempty"`
+	Fallback string `bson:"fallback" json:"fallback" yaml:"fallback"`
+
+	AuthorName    string `bson:"author_name,omitempty" json:"author_name,omitempty" yaml:"author_name,omitempty"`
+	AuthorSubname string `bson:"author_subname,omitempty" json:"author_subname,omitempty" yaml:"author_subname,omitempty"`
+	AuthorLink    string `bson:"author_link,omitempty" json:"author_link,omitempty" yaml:"author_link,omitempty"`
+	AuthorIcon    string `bson:"author_icon,omitempty" json:"author_icon,omitempty" yaml:"author_icon,omitempty"`
+
+	Title     string `bson:"title,omitempty" json:"title,omitempty" yaml:"title,omitempty"`
+	TitleLink string `bson:"title_link,omitempty" json:"title_link,omitempty" yaml:"title_link,omitempty"`
+	Pretext   string `bson:"pretext,omitempty" json:"pretext,omitempty" yaml:"pretext,omitempty"`
+	Text      string `bson:"text" json:"text" yaml:"text"`
+
+	ImageURL string `bson:"image_url,omitempty" json:"image_url,omitempty" yaml:"image_url,omitempty"`
+	ThumbURL string `bson:"thumb_url,omitempty" json:"thumb_url,omitempty" yaml:"thumb_url,omitempty"`
+
+	Footer     string `bson:"footer,omitempty" json:"footer,omitempty" yaml:"footer,omitempty"`
+	FooterIcon string `bson:"footer_icon,omitempty" json:"footer_icon,omitempty" yaml:"footer_icon,omitempty"`
+
+	Fields     []*SlackAttachmentField `bson:"fields,omitempty" json:"fields,omitempty" yaml:"fields,omitempty"`
+	MarkdownIn []string                `bson:"mrkdwn_in,omitempty" json:"mrkdwn_in,omitempty" yaml:"mrkdwn_in,omitempty"`
+}
+
+func (s *SlackAttachment) convert() *slack.Attachment {
+	const skipField = "Fields"
+	at := slack.Attachment{}
+
+	vGrip := reflect.ValueOf(s).Elem()
+	tGrip := reflect.TypeOf(s).Elem()
+	vSlack := reflect.ValueOf(&at).Elem()
+	for fNum := 0; fNum < vGrip.NumField(); fNum++ {
+		gripField := vGrip.Field(fNum)
+		gripFieldName := tGrip.Field(fNum).Name
+		slackField := vSlack.FieldByName(gripFieldName)
+		if gripFieldName != skipField {
+			slackField.Set(gripField)
+
+		} else {
+			at.Fields = make([]*slack.AttachmentField, 0, len(s.Fields))
+
+			for i := range s.Fields {
+				at.Fields = append(at.Fields, s.Fields[i].convert())
+			}
+		}
+	}
+
+	return &at
+}
+
+// SlackAttachmentField is one of the optional fields that can be attached
+// to a slack message. This type is the same as bluele/slack.AttachmentField
+type SlackAttachmentField struct {
+	Title string `bson:"title" json:"title" yaml:"title"`
+	Value string `bson:"value" json:"value" yaml:"value"`
+	Short bool   `bson:"short" json:"short" yaml:"short"`
+}
+
+func (s *SlackAttachmentField) convert() *slack.AttachmentField {
+	af := slack.AttachmentField{}
+
+	vGrip := reflect.ValueOf(s).Elem()
+	tGrip := reflect.TypeOf(s).Elem()
+	vSlack := reflect.ValueOf(&af).Elem()
+	for fNum := 0; fNum < vGrip.NumField(); fNum++ {
+		gripField := vGrip.Field(fNum)
+		gripFieldName := tGrip.Field(fNum).Name
+		slackField := vSlack.FieldByName(gripFieldName)
+		slackField.Set(gripField)
+	}
+
+	return &af
 }
 
 type slackMessage struct {
@@ -21,7 +99,15 @@ type slackMessage struct {
 }
 
 // NewSlackMessage creates a composer for messages to slack
-func NewSlackMessage(p level.Priority, target string, msg string, attachments []*slack.Attachment) Composer {
+func NewSlackMessage(p level.Priority, target string, msg string, attachments []SlackAttachment) Composer {
+	s := MakeSlackMessage(target, msg, attachments)
+	_ = s.SetPriority(p)
+
+	return s
+}
+
+// MakeSlackMessage creates a composer for message to slack without a priority
+func MakeSlackMessage(target string, msg string, attachments []SlackAttachment) Composer {
 	s := &slackMessage{
 		raw: Slack{
 			Target: target,
@@ -29,16 +115,19 @@ func NewSlackMessage(p level.Priority, target string, msg string, attachments []
 		},
 	}
 	if len(attachments) != 0 {
-		s.raw.Attachments = attachments
-	}
+		s.raw.Attachments = make([]*slack.Attachment, 0, len(attachments))
 
-	_ = s.SetPriority(p)
+		for i := range attachments {
+			at := attachments[i].convert()
+			s.raw.Attachments = append(s.raw.Attachments, at)
+		}
+	}
 
 	return s
 }
 
 func (c *slackMessage) Loggable() bool {
-	return len(c.raw.Msg) != 0
+	return len(c.raw.Target) != 0 && len(c.raw.Msg) != 0
 }
 
 func (c *slackMessage) String() string {
@@ -47,4 +136,25 @@ func (c *slackMessage) String() string {
 
 func (c *slackMessage) Raw() interface{} {
 	return &c.raw
+}
+
+// Annotate adds additional attachments to the message. The key value is ignored
+func (c *slackMessage) Annotate(_ string, data interface{}) error {
+	var annotate *SlackAttachment
+
+	switch v := data.(type) {
+	case *SlackAttachment:
+		annotate = v
+	case SlackAttachment:
+		annotate = &v
+	default:
+		return errors.New("Annotate only accepts SlackAttachment, or *SlackAttachment")
+	}
+	if annotate == nil {
+		return errors.New("Annotate data must not be nil")
+	}
+
+	c.raw.Attachments = append(c.raw.Attachments, annotate.convert())
+
+	return nil
 }

--- a/message/slack.go
+++ b/message/slack.go
@@ -18,7 +18,7 @@ const (
 
 // Slack is a message to a Slack channel or user
 type Slack struct {
-	Target      string              `bson:"target,omitempty" json:"target,omitempty" yaml:"target,omitempty"`
+	Target      string              `bson:"target" json:"target" yaml:"target"`
 	Msg         string              `bson:"msg" json:"msg" yaml:"msg"`
 	Attachments []*slack.Attachment `bson:"attachments" json:"attachments" yaml:"attachments"`
 }
@@ -29,21 +29,12 @@ type SlackAttachment struct {
 	Color    string `bson:"color,omitempty" json:"color,omitempty" yaml:"color,omitempty"`
 	Fallback string `bson:"fallback" json:"fallback" yaml:"fallback"`
 
-	AuthorName    string `bson:"author_name,omitempty" json:"author_name,omitempty" yaml:"author_name,omitempty"`
-	AuthorSubname string `bson:"author_subname,omitempty" json:"author_subname,omitempty" yaml:"author_subname,omitempty"`
-	AuthorLink    string `bson:"author_link,omitempty" json:"author_link,omitempty" yaml:"author_link,omitempty"`
-	AuthorIcon    string `bson:"author_icon,omitempty" json:"author_icon,omitempty" yaml:"author_icon,omitempty"`
+	AuthorName string `bson:"author_name,omitempty" json:"author_name,omitempty" yaml:"author_name,omitempty"`
+	AuthorIcon string `bson:"author_icon,omitempty" json:"author_icon,omitempty" yaml:"author_icon,omitempty"`
 
 	Title     string `bson:"title,omitempty" json:"title,omitempty" yaml:"title,omitempty"`
 	TitleLink string `bson:"title_link,omitempty" json:"title_link,omitempty" yaml:"title_link,omitempty"`
-	Pretext   string `bson:"pretext,omitempty" json:"pretext,omitempty" yaml:"pretext,omitempty"`
 	Text      string `bson:"text" json:"text" yaml:"text"`
-
-	ImageURL string `bson:"image_url,omitempty" json:"image_url,omitempty" yaml:"image_url,omitempty"`
-	ThumbURL string `bson:"thumb_url,omitempty" json:"thumb_url,omitempty" yaml:"thumb_url,omitempty"`
-
-	Footer     string `bson:"footer,omitempty" json:"footer,omitempty" yaml:"footer,omitempty"`
-	FooterIcon string `bson:"footer_icon,omitempty" json:"footer_icon,omitempty" yaml:"footer_icon,omitempty"`
 
 	Fields     []*SlackAttachmentField `bson:"fields,omitempty" json:"fields,omitempty" yaml:"fields,omitempty"`
 	MarkdownIn []string                `bson:"mrkdwn_in,omitempty" json:"mrkdwn_in,omitempty" yaml:"mrkdwn_in,omitempty"`
@@ -134,13 +125,13 @@ func MakeSlackMessage(target string, msg string, attachments []SlackAttachment) 
 }
 
 func (c *slackMessage) Loggable() bool {
-	if len(c.raw.Target) != 0 {
+	if len(c.raw.Target) == 0 {
 		return false
 	}
-	if len(c.raw.Msg) != 0 {
+	if len(c.raw.Msg) == 0 {
 		return false
 	}
-	if len(c.raw.Attachments) <= slackMaxAttachments {
+	if len(c.raw.Attachments) > slackMaxAttachments {
 		return false
 	}
 
@@ -172,7 +163,7 @@ func (c *slackMessage) Annotate(key string, data interface{}) error {
 		return errors.New("Annotate data must not be nil")
 	}
 	if len(c.raw.Attachments) == slackMaxAttachments {
-		return fmt.Errorf("Adding another slack attachment would exceed maximum number of attachments, %d", slackMaxAttachments)
+		return fmt.Errorf("Adding another Slack attachment would exceed maximum number of attachments, %d", slackMaxAttachments)
 	}
 
 	c.raw.Attachments = append(c.raw.Attachments, annotate.convert())

--- a/message/slack.go
+++ b/message/slack.go
@@ -139,7 +139,8 @@ func (c *slackMessage) Raw() interface{} {
 }
 
 // Annotate adds additional attachments to the message. The key value is ignored
-func (c *slackMessage) Annotate(_ string, data interface{}) error {
+// if a SlackAttachment or *SlackAttachment is supplied
+func (c *slackMessage) Annotate(key string, data interface{}) error {
 	var annotate *SlackAttachment
 
 	switch v := data.(type) {
@@ -148,7 +149,7 @@ func (c *slackMessage) Annotate(_ string, data interface{}) error {
 	case SlackAttachment:
 		annotate = &v
 	default:
-		return errors.New("Annotate only accepts SlackAttachment, or *SlackAttachment")
+		return c.Base.Annotate(key, data)
 	}
 	if annotate == nil {
 		return errors.New("Annotate data must not be nil")

--- a/message/slack.go
+++ b/message/slack.go
@@ -10,6 +10,9 @@ import (
 )
 
 const (
+	// slackMaxAttachments is the maximum number of attachments a single
+	// Slack message may have, per the Slack API documentation:
+	// https://api.slack.com/docs/message-attachments#attachment_limits
 	slackMaxAttachments = 100
 )
 
@@ -131,7 +134,17 @@ func MakeSlackMessage(target string, msg string, attachments []SlackAttachment) 
 }
 
 func (c *slackMessage) Loggable() bool {
-	return len(c.raw.Target) != 0 && len(c.raw.Msg) != 0 && len(c.raw.Attachments) <= slackMaxAttachments
+	if len(c.raw.Target) != 0 {
+		return false
+	}
+	if len(c.raw.Msg) != 0 {
+		return false
+	}
+	if len(c.raw.Attachments) <= slackMaxAttachments {
+		return false
+	}
+
+	return true
 }
 
 func (c *slackMessage) String() string {

--- a/message/slack.go
+++ b/message/slack.go
@@ -159,7 +159,7 @@ func (c *slackMessage) Annotate(key string, data interface{}) error {
 		return errors.New("Annotate data must not be nil")
 	}
 	if len(c.raw.Attachments) == slackMaxAttachments {
-		return errors.Errorf("Adding another slack attachment would exceed maximum number of attachments, %d", slackMaxAttachments)
+		return fmt.Errorf("Adding another slack attachment would exceed maximum number of attachments, %d", slackMaxAttachments)
 	}
 
 	c.raw.Attachments = append(c.raw.Attachments, annotate.convert())

--- a/message/slack_test.go
+++ b/message/slack_test.go
@@ -33,39 +33,25 @@ func TestSlackAttachmentConvert(t *testing.T) {
 	}
 
 	at := SlackAttachment{
-		Color:         "1",
-		Fallback:      "2",
-		AuthorName:    "3",
-		AuthorSubname: "4",
-		AuthorLink:    "5",
-		AuthorIcon:    "6",
-		Title:         "7",
-		TitleLink:     "8",
-		Pretext:       "9",
-		Text:          "10",
-		ImageURL:      "11",
-		ThumbURL:      "12",
-		Footer:        "13",
-		FooterIcon:    "14",
-		Fields:        []*SlackAttachmentField{&af},
-		MarkdownIn:    []string{"15", "16"},
+		Color:      "1",
+		Fallback:   "2",
+		AuthorName: "3",
+		AuthorIcon: "6",
+		Title:      "7",
+		TitleLink:  "8",
+		Text:       "10",
+		Fields:     []*SlackAttachmentField{&af},
+		MarkdownIn: []string{"15", "16"},
 	}
 	slackAttachment := at.convert()
 
 	assert.Equal("1", slackAttachment.Color)
 	assert.Equal("2", slackAttachment.Fallback)
 	assert.Equal("3", slackAttachment.AuthorName)
-	assert.Equal("4", slackAttachment.AuthorSubname)
-	assert.Equal("5", slackAttachment.AuthorLink)
 	assert.Equal("6", slackAttachment.AuthorIcon)
 	assert.Equal("7", slackAttachment.Title)
 	assert.Equal("8", slackAttachment.TitleLink)
-	assert.Equal("9", slackAttachment.Pretext)
 	assert.Equal("10", slackAttachment.Text)
-	assert.Equal("11", slackAttachment.ImageURL)
-	assert.Equal("12", slackAttachment.ThumbURL)
-	assert.Equal("13", slackAttachment.Footer)
-	assert.Equal("14", slackAttachment.FooterIcon)
 	assert.Equal([]string{"15", "16"}, slackAttachment.MarkdownIn)
 	assert.Len(slackAttachment.Fields, 1)
 	assert.Equal("1", slackAttachment.Fields[0].Title)
@@ -82,11 +68,9 @@ func TestSlackAttachmentIsSame(t *testing.T) {
 	vGrip := reflect.TypeOf(grip)
 	vSlack := reflect.TypeOf(slack)
 
-	assert.Equal(vSlack.NumField(), vGrip.NumField())
 	for i := 0; i < vSlack.NumField(); i++ {
 		slackField := vSlack.Field(i)
 		gripField, found := vGrip.FieldByName(slackField.Name)
-		assert.True(found, "field %s found in slack.Attachment, but not in message.SlackAttachment", slackField.Name)
 		if !found {
 			continue
 		}

--- a/message/slack_test.go
+++ b/message/slack_test.go
@@ -1,24 +1,135 @@
 package message
 
 import (
+	"reflect"
 	"testing"
 
-	"github.com/mongodb/grip/level"
+	"github.com/bluele/slack"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestSlackMessage(t *testing.T) {
+func TestSlackAttachmentFieldConvert(t *testing.T) {
 	assert := assert.New(t) //nolint
 
-	m := NewSlackMessage(level.Notice, "abc", "i'm awesome", nil)
-	assert.True(m.Loggable())
-	assert.Equal("abc: i'm awesome", m.String())
-	_, ok := m.Raw().(*Slack)
-	assert.True(ok)
+	gripField := SlackAttachmentField{
+		Title: "1",
+		Value: "2",
+		Short: true,
+	}
+	slackField := gripField.convert()
 
-	m = NewSlackMessage(level.Notice, "", "i'm awesome", nil)
-	assert.True(m.Loggable())
+	assert.Equal("1", slackField.Title)
+	assert.Equal("2", slackField.Value)
+	assert.True(slackField.Short)
+}
 
-	m = NewSlackMessage(level.Notice, "abc", "", nil)
-	assert.False(m.Loggable())
+func TestSlackAttachmentConvert(t *testing.T) {
+	assert := assert.New(t) //nolint
+
+	af := SlackAttachmentField{
+		Title: "1",
+		Value: "2",
+		Short: true,
+	}
+
+	at := SlackAttachment{
+		Color:         "1",
+		Fallback:      "2",
+		AuthorName:    "3",
+		AuthorSubname: "4",
+		AuthorLink:    "5",
+		AuthorIcon:    "6",
+		Title:         "7",
+		TitleLink:     "8",
+		Pretext:       "9",
+		Text:          "10",
+		ImageURL:      "11",
+		ThumbURL:      "12",
+		Footer:        "13",
+		FooterIcon:    "14",
+		Fields:        []*SlackAttachmentField{&af},
+		MarkdownIn:    []string{"15", "16"},
+	}
+	slackAttachment := at.convert()
+
+	assert.Equal("1", slackAttachment.Color)
+	assert.Equal("2", slackAttachment.Fallback)
+	assert.Equal("3", slackAttachment.AuthorName)
+	assert.Equal("4", slackAttachment.AuthorSubname)
+	assert.Equal("5", slackAttachment.AuthorLink)
+	assert.Equal("6", slackAttachment.AuthorIcon)
+	assert.Equal("7", slackAttachment.Title)
+	assert.Equal("8", slackAttachment.TitleLink)
+	assert.Equal("9", slackAttachment.Pretext)
+	assert.Equal("10", slackAttachment.Text)
+	assert.Equal("11", slackAttachment.ImageURL)
+	assert.Equal("12", slackAttachment.ThumbURL)
+	assert.Equal("13", slackAttachment.Footer)
+	assert.Equal("14", slackAttachment.FooterIcon)
+	assert.Equal([]string{"15", "16"}, slackAttachment.MarkdownIn)
+	assert.Len(slackAttachment.Fields, 1)
+	assert.Equal("1", slackAttachment.Fields[0].Title)
+	assert.Equal("2", slackAttachment.Fields[0].Value)
+	assert.True(slackAttachment.Fields[0].Short)
+}
+
+func TestSlackAttachmentIsSame(t *testing.T) {
+	assert := assert.New(t) //nolint
+
+	grip := SlackAttachment{}
+	slack := slack.Attachment{}
+
+	vGrip := reflect.TypeOf(grip)
+	vSlack := reflect.TypeOf(slack)
+
+	assert.Equal(vSlack.NumField(), vGrip.NumField())
+	for i := 0; i < vSlack.NumField(); i++ {
+		slackField := vSlack.Field(i)
+		gripField, found := vGrip.FieldByName(slackField.Name)
+		assert.True(found, "field %s found in slack.Attachment, but not in message.SlackAttachment", slackField.Name)
+		if !found {
+			continue
+		}
+
+		referenceTag := slackField.Tag.Get("json")
+		assert.NotEmpty(referenceTag)
+		jsonTag := gripField.Tag.Get("json")
+		assert.Equal(referenceTag, jsonTag, "SlackAttachment.%s should have json tag with value: \"%s\"", gripField.Name, referenceTag)
+		bsonTag := gripField.Tag.Get("bson")
+		assert.Equal(referenceTag, bsonTag, "SlackAttachment.%s should have bson tag with value: \"%s\"", gripField.Name, referenceTag)
+		yamlTag := gripField.Tag.Get("yaml")
+		assert.Equal(referenceTag, yamlTag, "SlackAttachment.%s should have yaml tag with value: \"%s\"", gripField.Name, referenceTag)
+	}
+
+}
+
+func TestSlackAttachmentFieldIsSame(t *testing.T) {
+	assert := assert.New(t) //nolint
+
+	gripStruct := SlackAttachmentField{}
+	slackStruct := slack.AttachmentField{}
+
+	vGrip := reflect.TypeOf(gripStruct)
+	vSlack := reflect.TypeOf(slackStruct)
+
+	assert.Equal(vSlack.NumField(), vGrip.NumField())
+	for i := 0; i < vSlack.NumField(); i++ {
+		slackField := vSlack.Field(i)
+		gripField, found := vGrip.FieldByName(slackField.Name)
+		assert.True(found, "field %s found in slack.AttachmentField, but not in message.SlackAttachmentField", slackField.Name)
+		if !found {
+			continue
+		}
+
+		referenceTag := slackField.Tag.Get("json")
+		assert.NotEmpty(referenceTag)
+		jsonTag := gripField.Tag.Get("json")
+		assert.Equal(referenceTag, jsonTag, "SlackAttachmentField.%s should have json tag with value: \"%s\"", gripField.Name, referenceTag)
+		bsonTag := gripField.Tag.Get("bson")
+		assert.Equal(referenceTag, bsonTag, "SlackAttachmentField.%s should have bson tag with value: \"%s\"", gripField.Name, referenceTag)
+		yamlTag := gripField.Tag.Get("yaml")
+		assert.Equal(referenceTag, yamlTag, "SlackAttachmentField.%s should have yaml tag with value: \"%s\"", gripField.Name, referenceTag)
+
+		assert.Equal(slackField.Type.Kind(), gripField.Type.Kind())
+	}
 }

--- a/message/slack_test.go
+++ b/message/slack_test.go
@@ -1,0 +1,24 @@
+package message
+
+import (
+	"testing"
+
+	"github.com/mongodb/grip/level"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSlackMessage(t *testing.T) {
+	assert := assert.New(t) //nolint
+
+	m := NewSlackMessage(level.Notice, "abc", "i'm awesome", nil)
+	assert.True(m.Loggable())
+	assert.Equal("abc: i'm awesome", m.String())
+	_, ok := m.Raw().(*Slack)
+	assert.True(ok)
+
+	m = NewSlackMessage(level.Notice, "", "i'm awesome", nil)
+	assert.True(m.Loggable())
+
+	m = NewSlackMessage(level.Notice, "abc", "", nil)
+	assert.False(m.Loggable())
+}

--- a/send/github_client_mock_test.go
+++ b/send/github_client_mock_test.go
@@ -3,6 +3,7 @@ package send
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/google/go-github/github"
 )
@@ -10,6 +11,8 @@ import (
 type githubClientMock struct {
 	failSend bool
 	numSent  int
+
+	lastRepo string
 }
 
 func (g *githubClientMock) Init(_ context.Context, _ string) {}
@@ -31,11 +34,12 @@ func (g *githubClientMock) CreateComment(_ context.Context, _ string, _ string, 
 	return nil, nil, nil
 }
 
-func (g *githubClientMock) CreateStatus(_ context.Context, _, _, _ string, _ *github.RepoStatus) (*github.RepoStatus, *github.Response, error) {
+func (g *githubClientMock) CreateStatus(_ context.Context, repo, owner, ref string, _ *github.RepoStatus) (*github.RepoStatus, *github.Response, error) {
 	if g.failSend {
 		return nil, nil, errors.New("failed to create status")
 	}
 
 	g.numSent++
+	g.lastRepo = fmt.Sprintf("%s/%s@%s", repo, owner, ref)
 	return nil, nil, nil
 }

--- a/send/github_status.go
+++ b/send/github_status.go
@@ -11,7 +11,7 @@ import (
 	"github.com/mongodb/grip/message"
 )
 
-type githubStatusLogger struct {
+type githubStatusMessageLogger struct {
 	opts *GithubOptions
 	ref  string
 
@@ -19,7 +19,7 @@ type githubStatusLogger struct {
 	*Base
 }
 
-func (s *githubStatusLogger) Send(m message.Composer) {
+func (s *githubStatusMessageLogger) Send(m message.Composer) {
 	if s.Level().ShouldLog(m) {
 		var status *github.RepoStatus
 		owner := ""
@@ -28,14 +28,14 @@ func (s *githubStatusLogger) Send(m message.Composer) {
 
 		switch v := m.Raw().(type) {
 		case *message.GithubStatus:
-			status = githubStatusPayloadToRepoStatus(v)
+			status = githubStatusMessagePayloadToRepoStatus(v)
 			if v != nil {
 				owner = v.Owner
 				repo = v.Repo
 				ref = v.Ref
 			}
 		case message.GithubStatus:
-			status = githubStatusPayloadToRepoStatus(&v)
+			status = githubStatusMessagePayloadToRepoStatus(&v)
 			owner = v.Owner
 			repo = v.Repo
 			ref = v.Ref
@@ -71,7 +71,7 @@ func (s *githubStatusLogger) Send(m message.Composer) {
 // NewGithubStatusLogger returns a Sender to send payloads to the Github Status
 // API. Statuses will be attached to the given ref.
 func NewGithubStatusLogger(name string, opts *GithubOptions, ref string) (Sender, error) {
-	s := &githubStatusLogger{
+	s := &githubStatusMessageLogger{
 		Base: NewBase(name),
 		gh:   &githubClientImpl{},
 		ref:  ref,
@@ -98,7 +98,7 @@ func NewGithubStatusLogger(name string, opts *GithubOptions, ref string) (Sender
 	return s, nil
 }
 
-func (s *githubStatusLogger) githubMessageFieldsToStatus(m *message.Fields) *github.RepoStatus {
+func (s *githubStatusMessageLogger) githubMessageFieldsToStatus(m *message.Fields) *github.RepoStatus {
 	if m == nil {
 		return nil
 	}
@@ -146,7 +146,7 @@ func getStringPtrFromField(i interface{}) (*string, bool) {
 
 	return nil, false
 }
-func githubStatusPayloadToRepoStatus(c *message.GithubStatus) *github.RepoStatus {
+func githubStatusMessagePayloadToRepoStatus(c *message.GithubStatus) *github.RepoStatus {
 	if c == nil {
 		return nil
 	}

--- a/send/github_status.go
+++ b/send/github_status.go
@@ -22,21 +22,46 @@ type githubStatusLogger struct {
 func (s *githubStatusLogger) Send(m message.Composer) {
 	if s.Level().ShouldLog(m) {
 		var status *github.RepoStatus
+		owner := ""
+		repo := ""
+		ref := ""
 
 		switch v := m.Raw().(type) {
-		case *github.RepoStatus:
-			status = v
+		case *message.GithubStatus:
+			status = githubStatusPayloadToRepoStatus(v)
+			if v != nil {
+				owner = v.Owner
+				repo = v.Repo
+				ref = v.Ref
+			}
+		case message.GithubStatus:
+			status = githubStatusPayloadToRepoStatus(&v)
+			owner = v.Owner
+			repo = v.Repo
+			ref = v.Ref
+
 		case *message.Fields:
-			status = githubMessageFieldsToStatus(v)
+			status = s.githubMessageFieldsToStatus(v)
+			owner, repo, ref = githubMessageFieldsToRepo(v)
 		case message.Fields:
-			status = githubMessageFieldsToStatus(&v)
+			status = s.githubMessageFieldsToStatus(&v)
+			owner, repo, ref = githubMessageFieldsToRepo(&v)
+		}
+		if len(owner) == 0 {
+			owner = s.opts.Account
+		}
+		if len(repo) == 0 {
+			owner = s.opts.Repo
+		}
+		if len(ref) == 0 {
+			owner = s.ref
 		}
 		if status == nil {
 			s.ErrorHandler(errors.New("composer cannot be converted to github status"), m)
 			return
 		}
 
-		_, _, err := s.gh.CreateStatus(context.TODO(), s.opts.Account, s.opts.Repo, s.ref, status)
+		_, _, err := s.gh.CreateStatus(context.TODO(), owner, repo, ref, status)
 		if err != nil {
 			s.ErrorHandler(err, m)
 		}
@@ -68,10 +93,12 @@ func NewGithubStatusLogger(name string, opts *GithubOptions, ref string) (Sender
 		fallback.SetPrefix(fmt.Sprintf("[%s] [%s/%s] ", s.Name(), opts.Account, opts.Repo))
 	}
 
+	s.SetName(name)
+
 	return s, nil
 }
 
-func githubMessageFieldsToStatus(m *message.Fields) *github.RepoStatus {
+func (s *githubStatusLogger) githubMessageFieldsToStatus(m *message.Fields) *github.RepoStatus {
 	if m == nil {
 		return nil
 	}
@@ -99,12 +126,14 @@ func githubMessageFieldsToStatus(m *message.Fields) *github.RepoStatus {
 		}
 	}
 
-	return &github.RepoStatus{
+	status := &github.RepoStatus{
 		State:       state,
 		Context:     context,
 		URL:         URL,
 		Description: description,
 	}
+
+	return status
 }
 
 func getStringPtrFromField(i interface{}) (*string, bool) {
@@ -116,4 +145,41 @@ func getStringPtrFromField(i interface{}) (*string, bool) {
 	}
 
 	return nil, false
+}
+func githubStatusPayloadToRepoStatus(c *message.GithubStatus) *github.RepoStatus {
+	if c == nil {
+		return nil
+	}
+
+	s := &github.RepoStatus{
+		Context: github.String(c.Context),
+		State:   github.String(string(c.State)),
+		URL:     github.String(c.URL),
+	}
+	if len(c.Description) > 0 {
+		s.Description = github.String(c.Description)
+	}
+
+	return s
+}
+
+func githubMessageFieldsToRepo(m *message.Fields) (string, string, string) {
+	if m == nil {
+		return "", "", ""
+	}
+
+	owner, ok := getStringPtrFromField((*m)["owner"])
+	if !ok {
+		owner = github.String("")
+	}
+	repo, ok := getStringPtrFromField((*m)["repo"])
+	if !ok {
+		repo = github.String("")
+	}
+	ref, ok := getStringPtrFromField((*m)["ref"])
+	if !ok {
+		ref = github.String("")
+	}
+
+	return *owner, *repo, *ref
 }

--- a/send/jira_comment.go
+++ b/send/jira_comment.go
@@ -63,7 +63,7 @@ func NewJiraCommentLogger(id string, opts *JiraOptions, l LevelInfo) (Sender, er
 func (j *jiraCommentJournal) Send(m message.Composer) {
 	if j.Level().ShouldLog(m) {
 		issue := j.issueID
-		if c, ok := m.Raw().(*message.JIRAPayload); ok {
+		if c, ok := m.Raw().(*message.JIRAComment); ok {
 			issue = c.IssueID
 		}
 		if err := j.opts.client.PostComment(issue, m.String()); err != nil {

--- a/send/jira_comment.go
+++ b/send/jira_comment.go
@@ -62,7 +62,11 @@ func NewJiraCommentLogger(id string, opts *JiraOptions, l LevelInfo) (Sender, er
 // Send post issues via jiraCommentJournal with information in the message.Composer
 func (j *jiraCommentJournal) Send(m message.Composer) {
 	if j.Level().ShouldLog(m) {
-		if err := j.opts.client.PostComment(j.issueID, m.String()); err != nil {
+		issue := j.issueID
+		if c, ok := m.Raw().(*message.JIRAPayload); ok {
+			issue = c.IssueID
+		}
+		if err := j.opts.client.PostComment(issue, m.String()); err != nil {
 			j.ErrorHandler(err, m)
 		}
 	}

--- a/send/jira_comment_test.go
+++ b/send/jira_comment_test.go
@@ -111,7 +111,7 @@ func (j *JiraCommentSuite) TestCreateMethodChangesClientState() {
 }
 
 func (j *JiraCommentSuite) TestSendWithJiraIssueComposer() {
-	c := message.NewJIRAComment(level.Notice, "ABC-123", "Hi")
+	c := message.NewJIRACommentMessage(level.Notice, "ABC-123", "Hi")
 
 	sender, err := NewJiraCommentLogger("XYZ-123", j.opts, LevelInfo{level.Trace, level.Info})
 	j.NoError(err)

--- a/send/jira_comment_test.go
+++ b/send/jira_comment_test.go
@@ -109,3 +109,18 @@ func (j *JiraCommentSuite) TestCreateMethodChangesClientState() {
 	j.NoError(new.CreateClient(nil, "foo"))
 	j.NotEqual(base, new)
 }
+
+func (j *JiraCommentSuite) TestSendWithJiraIssueComposer() {
+	c := message.NewJIRAComment(level.Notice, "ABC-123", "Hi")
+
+	sender, err := NewJiraCommentLogger("XYZ-123", j.opts, LevelInfo{level.Trace, level.Info})
+	j.NoError(err)
+	j.Require().NotNil(sender)
+
+	sender.Send(c)
+
+	mock, ok := j.opts.client.(*jiraClientMock)
+	j.True(ok)
+	j.Equal(1, mock.numSent)
+	j.Equal("ABC-123", mock.lastIssue)
+}

--- a/send/jira_mock_test.go
+++ b/send/jira_mock_test.go
@@ -12,6 +12,8 @@ type jiraClientMock struct {
 	failAuth   bool
 	failSend   bool
 	numSent    int
+
+	lastIssue string
 }
 
 func (j *jiraClientMock) CreateClient(_ *http.Client, _ string) error {
@@ -44,6 +46,7 @@ func (j *jiraClientMock) PostComment(issueID string, comment string) error {
 	}
 
 	j.numSent++
+	j.lastIssue = issueID
 
 	return nil
 }

--- a/send/send_test.go
+++ b/send/send_test.go
@@ -327,12 +327,28 @@ func (s *SenderSuite) TestGithubStatusLogger() {
 	sender.Send(c)
 	s.Equal(1, client.numSent)
 
+	// WithRepo constructor should override sender's defaults
+	p := message.GithubStatus{
+		Owner:       "somewhere",
+		Repo:        "over",
+		Ref:         "therainbow",
+		Context:     "example",
+		State:       message.GithubStatePending,
+		URL:         "https://example.com/hi",
+		Description: "description",
+	}
+	c = message.NewGithubStatusWithRepo(level.Info, p)
+	s.True(c.Loggable())
+	sender.Send(c)
+	s.Equal(2, client.numSent)
+	s.Equal("somewhere/over@therainbow", client.lastRepo)
+
 	// don't send invalid messages
 	c = message.NewGithubStatus(level.Info, "", message.GithubStatePending,
 		"https://example.com/hi", "description")
 	s.False(c.Loggable())
 	sender.Send(c)
-	s.Equal(1, client.numSent)
+	s.Equal(2, client.numSent)
 }
 
 func (s *SenderSuite) TestGithubCommentLogger() {

--- a/send/send_test.go
+++ b/send/send_test.go
@@ -165,7 +165,7 @@ func (s *SenderSuite) SetupTest() {
 	}
 	s.NoError(s.senders["gh-comment-mocked"].SetFormatter(MakeDefaultFormatter()))
 
-	s.senders["gh-status-mocked"] = &githubStatusLogger{
+	s.senders["gh-status-mocked"] = &githubStatusMessageLogger{
 		Base: NewBase("gh-status-mocked"),
 		opts: &GithubOptions{},
 		gh:   &githubClientMock{},
@@ -305,12 +305,12 @@ func TestBaseConstructor(t *testing.T) {
 }
 
 func (s *SenderSuite) TestGithubStatusLogger() {
-	sender := s.senders["gh-status-mocked"].(*githubStatusLogger)
+	sender := s.senders["gh-status-mocked"].(*githubStatusMessageLogger)
 	client := sender.gh.(*githubClientMock)
 
 	// failed send test
 	client.failSend = true
-	c := message.NewGithubStatus(level.Info, "example", message.GithubStatePending,
+	c := message.NewGithubStatusMessage(level.Info, "example", message.GithubStatePending,
 		"https://example.com/hi", "description")
 
 	s.NoError(sender.SetErrorHandler(func(err error, c message.Composer) {
@@ -337,14 +337,14 @@ func (s *SenderSuite) TestGithubStatusLogger() {
 		URL:         "https://example.com/hi",
 		Description: "description",
 	}
-	c = message.NewGithubStatusWithRepo(level.Info, p)
+	c = message.NewGithubStatusMessageWithRepo(level.Info, p)
 	s.True(c.Loggable())
 	sender.Send(c)
 	s.Equal(2, client.numSent)
 	s.Equal("somewhere/over@therainbow", client.lastRepo)
 
 	// don't send invalid messages
-	c = message.NewGithubStatus(level.Info, "", message.GithubStatePending,
+	c = message.NewGithubStatusMessage(level.Info, "", message.GithubStatePending,
 		"https://example.com/hi", "description")
 	s.False(c.Loggable())
 	sender.Send(c)

--- a/send/slack.go
+++ b/send/slack.go
@@ -76,8 +76,21 @@ func (s *slackJournal) Send(m message.Composer) {
 		s.Base.mutex.RLock()
 		defer s.Base.mutex.RUnlock()
 
-		msg, params := s.opts.produceMessage(m)
-		if err := s.opts.client.ChatPostMessage(s.opts.Channel, msg, params); err != nil {
+		var msg string
+		var params *slack.ChatPostMessageOpt
+		channel := s.opts.Channel
+
+		if slackMsg, ok := m.Raw().(*message.Slack); ok {
+			channel = slackMsg.Target
+			msg, params = slackMsg.Msg, &slack.ChatPostMessageOpt{
+				Attachments: slackMsg.Attachments,
+			}
+
+		} else {
+			msg, params = s.opts.produceMessage(m)
+		}
+
+		if err := s.opts.client.ChatPostMessage(channel, msg, params); err != nil {
 			s.ErrorHandler(err, message.NewFormattedMessage(m.Priority(),
 				"%s: %s\n", params.Attachments[0].Fallback, msg))
 		}

--- a/send/slack_mock_test.go
+++ b/send/slack_mock_test.go
@@ -11,6 +11,7 @@ type slackClientMock struct {
 	failAuthTest       bool
 	failSendingMessage bool
 	numSent            int
+	lastTarget         string
 }
 
 func (c *slackClientMock) Create(_ string) {}
@@ -21,12 +22,13 @@ func (c *slackClientMock) AuthTest() (*slack.AuthTestApiResponse, error) {
 	return nil, nil
 }
 
-func (c *slackClientMock) ChatPostMessage(_, _ string, _ *slack.ChatPostMessageOpt) error {
+func (c *slackClientMock) ChatPostMessage(target, _ string, _ *slack.ChatPostMessageOpt) error {
 	if c.failSendingMessage {
 		return errors.New("mock failed auth test")
 	}
 
 	c.numSent++
+	c.lastTarget = target
 
 	return nil
 }

--- a/send/slack_test.go
+++ b/send/slack_test.go
@@ -261,6 +261,12 @@ func (s *SlackSuite) TestSendMethod() {
 	m = message.NewDefaultMessage(level.Alert, "world")
 	sender.Send(m)
 	s.Equal(mock.numSent, 1)
+	s.Equal("#test", mock.lastTarget)
+
+	m = message.NewSlackMessage(level.Alert, "#somewhere", "Hi", nil)
+	sender.Send(m)
+	s.Equal(mock.numSent, 2)
+	s.Equal("#somewhere", mock.lastTarget)
 }
 
 func (s *SlackSuite) TestSendMethodWithError() {


### PR DESCRIPTION
This change allows everything not related to authentication/server config to be be specified in the composers for JIRA, Slack, and the Github Status API. Email will be done in a separate ticket.