### PR TITLE
MAKE-397 Grip SMTP sender not sending correctly formatted RCPT command/not handling STARTTLS command

### DIFF
--- a/send/smtp.go
+++ b/send/smtp.go
@@ -337,13 +337,12 @@ func (o *SMTPOptions) sendMail(m message.Composer) error {
 
 	// Set the recipients
 	for _, target := range toAddrs {
-		addr := target.String()
-		if err = o.client.Rcpt(addr); err != nil {
+		if err = o.client.Rcpt(target.Address); err != nil {
 			errs = append(errs,
-				fmt.Sprintf("Error establishing mail recipient (%s): %+v", addr, err))
+				fmt.Sprintf("Error establishing mail recipient (%s): %+v", target.String(), err))
 			continue
 		}
-		recipients = append(recipients, addr)
+		recipients = append(recipients, target.String())
 	}
 	if len(errs) > 0 {
 		return errors.New(strings.Join(errs, "; "))
@@ -416,18 +415,24 @@ type smtpClientImpl struct {
 
 func (c *smtpClientImpl) Create(opts *SMTPOptions) error {
 	var err error
+	c.Client, err = smtp.Dial(fmt.Sprintf("%v:%v", opts.Server, opts.Port))
+	if err != nil {
+		return err
+	}
 
 	if opts.UseSSL {
-		var tlsCon *tls.Conn
-		tlsCon, err = tls.Dial("tcp", fmt.Sprintf("%v:%v", opts.Server, opts.Port), &tls.Config{})
+		config := &tls.Config{ServerName: opts.Server}
+		err = c.Client.StartTLS(config)
+
+	} else {
+		var hostname string
+		hostname, err = os.Hostname()
 		if err != nil {
 			return err
 		}
-		c.Client, err = smtp.NewClient(tlsCon, opts.Server)
-	} else {
-		c.Client, err = smtp.Dial(fmt.Sprintf("%v:%v", opts.Server, opts.Port))
-	}
 
+		err = c.Hello(hostname)
+	}
 	if err != nil {
 		return err
 	}

--- a/send/smtp.go
+++ b/send/smtp.go
@@ -328,7 +328,7 @@ func (o *SMTPOptions) sendMail(m message.Composer) error {
 	}
 
 	if err := o.client.Mail(fromAddr.Address); err != nil {
-		return fmt.Errorf("Error establishing mail sender (%s): %+v", fromAddr.String(), err)
+		return fmt.Errorf("Error establishing mail sender (%s): %+v", fromAddr, err)
 	}
 
 	var err error


### PR DESCRIPTION
1. Fixes RCPT (using only the mailbox address, "a@b.com" and not the whole address,"Someone <a@b.com>")
2. Fixes TLS. Because STARTTLS was not being issued, grip never actually supported sending email over TLS. Note that yes, by default it starts unencrypted, and initialises an encrypted connection after issuing STARTTLS, this is how encrypted email works.

On a side note, golang has smtp.SendMail which can replace most of the logic in the sender. Should I switch it to use that? It creates a connection per email, vs the sender's persistent connection.