### PR TITLE
Allow DevNullSender to write

### DIFF
--- a/slogger/appender.go
+++ b/slogger/appender.go
@@ -33,7 +33,7 @@ func StdErrAppender() send.Sender {
 // DevNullAppender returns a configured stream logger Sender instance
 // that writes messages to dev null.
 func DevNullAppender() (send.Sender, error) {
-	devNull, err := os.Open(os.DevNull)
+	devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0644)
 	if err != nil {
 		return nil, err
 	}

--- a/slogger/appender_test.go
+++ b/slogger/appender_test.go
@@ -1,0 +1,19 @@
+package slogger
+
+import (
+	"testing"
+
+	"github.com/mongodb/grip/level"
+	"github.com/mongodb/grip/message"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDevNull(t *testing.T) {
+	devNull, err := DevNullAppender()
+	assert.NoError(t, err)
+	devNull.SetErrorHandler(func(err error, c message.Composer) {
+		assert.Fail(t, "Send() should not fail for DevNullAppender()")
+	})
+
+	devNull.Send(message.NewDefaultMessage(level.Info, "foobar"))
+}


### PR DESCRIPTION
* DevNullAppender() currently errors with "bad file descriptor" error when sending because it is opened with read-only permissions.
* Should now open with write permissions.