### PR TITLE
MAKE-737: allow in-memory logs to be read in batches

### DIFF
--- a/message/fields.go
+++ b/message/fields.go
@@ -167,7 +167,7 @@ func (m *fieldMessage) String() string {
 			out = append(out, fmt.Sprintf(tmpl, k, v))
 		}
 
-		sort.Sort(sort.StringSlice(out))
+		sort.Strings(out)
 
 		m.cachedOutput = fmt.Sprintf("[%s]", strings.Join(out, " "))
 	}

--- a/message/slack.go
+++ b/message/slack.go
@@ -165,7 +165,7 @@ func (c *slackMessage) Annotate(key string, data interface{}) error {
 		return errors.New("Annotate data must not be nil")
 	}
 	if len(c.raw.Attachments) == slackMaxAttachments {
-		return fmt.Errorf("Adding another Slack attachment would exceed maximum number of attachments, %d", slackMaxAttachments)
+		return fmt.Errorf("adding another Slack attachment would exceed maximum number of attachments, %d", slackMaxAttachments)
 	}
 
 	c.raw.Attachments = append(c.raw.Attachments, annotate.convert())

--- a/send/buildlogger.go
+++ b/send/buildlogger.go
@@ -163,10 +163,12 @@ func (c *BuildloggerConfig) GetTestLogURL() string {
 	return fmt.Sprintf("%s/build/%s/test/%s", c.URL, c.buildID, c.testID)
 }
 
+// GetBuildID returns the build ID for the log currently in use.
 func (c *BuildloggerConfig) GetBuildID() string {
 	return c.buildID
 }
 
+// GetTestID returns the test ID for the log currently in use.
 func (c *BuildloggerConfig) GetTestID() string {
 	return c.testID
 }

--- a/send/inmemory.go
+++ b/send/inmemory.go
@@ -3,6 +3,7 @@ package send
 import (
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"sync"
@@ -10,13 +11,23 @@ import (
 	"github.com/mongodb/grip/message"
 )
 
+const (
+	readHeadNone      = -1
+	readHeadTruncated = -2
+)
+
+// ErrorTruncated means that the limited buffer capacity was overwritten.
+var ErrorTruncated = errors.New("buffer was truncated")
+
 // InMemorySender represents an in-memory buffered sender with a fixed message capacity.
 type InMemorySender struct {
 	Base
-	buffer         []message.Composer
-	mutex          sync.RWMutex
-	head           int
-	totalBytesSent int64
+	buffer           []message.Composer
+	mutex            sync.RWMutex
+	writeHead        int
+	readHead         int
+	readHeadCaughtUp bool
+	totalBytesSent   int64
 }
 
 // NewInMemorySender creates an in-memory buffered sender with the given capacity.
@@ -25,7 +36,11 @@ func NewInMemorySender(name string, info LevelInfo, capacity int) (Sender, error
 		return nil, errors.New("cannot have capacity <= 0")
 	}
 
-	s := &InMemorySender{Base: *NewBase(name), buffer: make([]message.Composer, 0, capacity)}
+	s := &InMemorySender{
+		Base:     *NewBase(name),
+		buffer:   make([]message.Composer, 0, capacity),
+		readHead: readHeadNone,
+	}
 	if err := s.Base.SetLevel(info); err != nil {
 		return nil, err
 	}
@@ -46,24 +61,108 @@ func NewInMemorySender(name string, info LevelInfo, capacity int) (Sender, error
 	return s, nil
 }
 
-// Get returns the messages in the buffer.
+func print(format string, args ...interface{}) {
+	fmt.Printf("kim: ")
+	fmt.Printf(format, args...)
+	fmt.Println()
+}
+
+func (s *InMemorySender) overflow() bool {
+	return len(s.buffer) == cap(s.buffer)
+}
+
+// GetCount returns at most count messages in the buffer as a stream. It returns
+// the messages and the number of messages returned. If the function is called
+// and reaches the end of the buffer, it returns io.EOF. If the position it is
+// currently reading at has been truncated, this returns ErrorTruncated. To
+// continue reading, the read stream must be reset using ResetRead.
+func (s *InMemorySender) GetCount(count int) ([]message.Composer, int, error) {
+	print("GetCount")
+	if count <= 0 {
+		return nil, 0, errors.New("cannot have count <= 0")
+	}
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	if len(s.buffer) == 0 {
+		return nil, 0, io.EOF
+	}
+
+	switch s.readHead {
+	case readHeadNone:
+		if !s.overflow() {
+			s.readHead = 0
+		} else {
+			s.readHead = s.writeHead
+		}
+	case readHeadTruncated:
+		return nil, 0, ErrorTruncated
+	}
+
+	print("old read head = %d, write head = %d", s.readHead, s.writeHead)
+	remaining := s.writeHead - s.readHead
+	print("remaining = %d", remaining)
+	if remaining < 0 {
+		// write head is below read head
+		remaining += len(s.buffer)
+		print("corrected remaining (for overflow): %d", remaining)
+	} else if remaining == 0 && !s.readHeadCaughtUp {
+		// write head and read head are even but the read head has just been
+		// initialized, so it still has to read all the buffer contents before
+		// being caught up
+		print("read head and write head are even but read head was just initialized")
+		remaining = len(s.buffer)
+	}
+	if remaining < count {
+		count = remaining
+	}
+	print("count = %d", count)
+	if count == 0 {
+		return nil, 0, io.EOF
+	}
+
+	defer func() {
+		s.readHead = (s.readHead + count) % cap(s.buffer)
+		// If read head is even with write head, it is caught up.
+		s.readHeadCaughtUp = s.readHead == s.writeHead
+		print("new read head = %d, caught up = %t", s.readHead, s.readHeadCaughtUp)
+	}()
+
+	start := s.readHead
+	end := s.readHead + count
+	print("start = %d, end = %d", start, end)
+
+	if end > len(s.buffer) {
+		end = end - len(s.buffer)
+		return append(s.buffer[start:len(s.buffer)], s.buffer[0:end]...), count, nil
+	}
+	return s.buffer[start:end], count, nil
+}
+
+// ResetRead resets the read stream used in GetCount.
+func (s *InMemorySender) ResetRead() {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+	s.readHead = readHeadNone
+	s.readHeadCaughtUp = false
+}
+
+// Get returns all the current messages in the buffer.
 func (s *InMemorySender) Get() []message.Composer {
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
 
-	var start int
-	var tmp []message.Composer
-
-	start = s.head - len(s.buffer)
+	start := s.writeHead - len(s.buffer)
 	if start < 0 {
 		start = start + len(s.buffer)
-		tmp = append(tmp, s.buffer[start:len(s.buffer)]...)
-		return append(tmp, s.buffer[:s.head]...)
+		tmp := append([]message.Composer{}, s.buffer[start:len(s.buffer)]...)
+		return append(tmp, s.buffer[:s.writeHead]...)
 	}
-	return append(tmp, s.buffer[start:s.head]...)
+	return s.buffer[start:s.writeHead]
 }
 
-// GetString returns the messages in the buffer as formatted strings.
+// GetString returns all the current messages in the buffer as formatted strings.
 func (s *InMemorySender) GetString() ([]string, error) {
 	msgs := s.Get()
 	strs := make([]string, 0, len(msgs))
@@ -77,7 +176,7 @@ func (s *InMemorySender) GetString() ([]string, error) {
 	return strs, nil
 }
 
-// GetRaw returns the messages in the buffer as empty interfaces.
+// GetRaw returns all the current messages in the buffer as empty interfaces.
 func (s *InMemorySender) GetRaw() []interface{} {
 	msgs := s.Get()
 	raw := make([]interface{}, 0, len(msgs))
@@ -87,22 +186,35 @@ func (s *InMemorySender) GetRaw() []interface{} {
 	return raw
 }
 
-// Send adds the given message to the buffer. If the buffer is at max capacity, it removes the oldest
-// message.
+// Send adds the given message to the buffer. If the buffer is at max capacity,
+// it truncates the oldest message.
 func (s *InMemorySender) Send(msg message.Composer) {
+	print("Send %s", msg.String())
 	if !s.Level().ShouldLog(msg) {
 		return
 	}
 
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
+	print("old write head = %d", s.writeHead)
+	if s.writeHead == s.readHead {
+		if s.readHeadCaughtUp {
+			// If read head was even with write head, it is not anymore.
+			s.readHeadCaughtUp = false
+			print("read head was caught up, but no longer caught up at position %d", s.writeHead)
+		} else {
+			s.readHead = readHeadTruncated
+			print("truncated read head at position %d", s.writeHead)
+		}
+	}
 
-	if len(s.buffer) < cap(s.buffer) {
+	if !s.overflow() {
 		s.buffer = append(s.buffer, msg)
 	} else {
-		s.buffer[s.head] = msg
+		s.buffer[s.writeHead] = msg
 	}
-	s.head = (s.head + 1) % cap(s.buffer)
+	s.writeHead = (s.writeHead + 1) % cap(s.buffer)
+	print("new write head = %d", s.writeHead)
 
 	s.totalBytesSent += int64(len(msg.String()))
 }

--- a/send/inmemory_test.go
+++ b/send/inmemory_test.go
@@ -2,6 +2,7 @@ package send
 
 import (
 	"fmt"
+	"io"
 	"testing"
 
 	"github.com/mongodb/grip/level"
@@ -45,6 +46,12 @@ func (s *InMemorySuite) SetupTest() {
 	s.Require().NoError(err)
 	s.Require().NotNil(sender)
 	s.sender = sender.(*InMemorySender)
+	s.Require().Empty(s.sender.buffer)
+	s.Require().Equal(readHeadNone, s.sender.readHead)
+	s.Require().False(s.sender.readHeadCaughtUp)
+	s.Require().Equal(0, s.sender.writeHead)
+	s.Require().Zero(s.sender.totalBytesSent)
+
 	s.msgs = make([]message.Composer, 2*s.maxCap)
 	for i := range s.msgs {
 		s.msgs[i] = message.NewDefaultMessage(info.Default, fmt.Sprint(i))
@@ -66,6 +73,246 @@ func (s *InMemorySuite) TestSendIgnoresMessagesWithPrioritiesBelowThreshold() {
 
 func (s *InMemorySuite) TestGetEmptyBuffer() {
 	s.Assert().Empty(s.sender.Get())
+}
+
+func (s *InMemorySuite) TestGetCountInvalidCount() {
+	msgs, n, err := s.sender.GetCount(-1)
+	s.Error(err)
+	s.Zero(n)
+	s.Nil(msgs)
+
+	msgs, n, err = s.sender.GetCount(0)
+	s.Error(err)
+	s.Zero(n)
+	s.Nil(msgs)
+}
+
+func (s *InMemorySuite) TestGetCountOne() {
+	for i := 0; i < s.maxCap-1; i++ {
+		s.sender.Send(s.msgs[i])
+	}
+	for i := 0; i < s.maxCap-1; i++ {
+		msgs, n, err := s.sender.GetCount(1)
+		s.Require().NoError(err)
+		s.Require().Equal(1, n)
+		s.Equal(s.msgs[i], msgs[0])
+	}
+
+	s.sender.Send(s.msgs[s.maxCap])
+
+	msgs, n, err := s.sender.GetCount(1)
+	s.Require().NoError(err)
+	s.Require().Equal(1, n)
+	s.Equal(s.msgs[s.maxCap], msgs[0])
+
+	msgs, n, err = s.sender.GetCount(1)
+	s.Require().Error(io.EOF, err)
+	s.Require().Equal(0, n)
+	s.Empty(msgs)
+}
+
+func (s *InMemorySuite) TestGetCountMultiple() {
+	for i := 0; i < s.maxCap; i++ {
+		s.sender.Send(s.msgs[i])
+	}
+
+	for count := 1; count <= s.maxCap; count++ {
+		s.sender.ResetRead()
+		for i := 0; i < s.maxCap; i += count {
+			msgs, n, err := s.sender.GetCount(count)
+			s.Require().NoError(err)
+			remaining := count
+			start := i
+			end := start + count
+			if end > s.maxCap {
+				end = s.maxCap
+				remaining = end - start
+			}
+			s.Equal(remaining, n)
+			s.Equal(s.msgs[start:end], msgs)
+		}
+		s.True(s.sender.readHeadCaughtUp)
+
+		_, _, err := s.sender.GetCount(count)
+		s.Require().Equal(io.EOF, err)
+	}
+}
+
+func (s *InMemorySuite) TestGetCountMultipleWithOverflow() {
+	for _, msg := range s.msgs {
+		s.sender.Send(msg)
+	}
+
+	for count := 1; count <= s.maxCap; count++ {
+		// print("***GetCount with count = %d***", count)
+		s.sender.ResetRead()
+		for i := 0; i < s.maxCap; i += count {
+			msgs, n, err := s.sender.GetCount(count)
+			s.Require().NoError(err)
+			remaining := count
+			start := len(s.msgs) - s.maxCap + i
+			end := start + count
+			if end > len(s.msgs) {
+				end = len(s.msgs)
+				remaining = end - start
+			}
+			s.Equal(remaining, n)
+			// print("actual message range: (%d, %d)", start, end)
+			s.Equal(s.msgs[start:end], msgs)
+		}
+		s.True(s.sender.readHeadCaughtUp)
+
+		_, _, err := s.sender.GetCount(count)
+		s.Require().Equal(io.EOF, err)
+	}
+}
+
+func (s *InMemorySuite) TestGetCountTruncated() {
+	s.sender.Send(s.msgs[0])
+	s.sender.Send(s.msgs[1])
+
+	msgs, n, err := s.sender.GetCount(1)
+	s.Require().NoError(err)
+	s.Equal(1, n)
+	s.Equal(s.msgs[0], msgs[0])
+	s.Require().False(s.sender.readHeadCaughtUp)
+
+	for i := 0; i < s.maxCap; i++ {
+		s.Require().NotEqual(readHeadTruncated, s.sender.readHead)
+		s.sender.Send(s.msgs[i])
+	}
+	s.Require().Equal(readHeadTruncated, s.sender.readHead)
+	_, _, err = s.sender.GetCount(1)
+	s.Require().Equal(ErrorTruncated, err)
+}
+
+func (s *InMemorySuite) TestGetCountWithCatchupTruncated() {
+	s.sender.Send(s.msgs[0])
+	msgs, n, err := s.sender.GetCount(1)
+	s.Require().NoError(err)
+	s.Equal(1, n)
+	s.Equal(s.msgs[0], msgs[0])
+	s.True(s.sender.readHeadCaughtUp)
+
+	for i := 0; i < s.maxCap; i++ {
+		s.Require().NotEqual(readHeadTruncated, s.sender.readHead)
+		s.sender.Send(s.msgs[i])
+		s.Require().False(s.sender.readHeadCaughtUp)
+	}
+	s.Require().False(s.sender.readHeadCaughtUp)
+	s.Require().NotEqual(readHeadTruncated, s.sender.readHead)
+
+	s.sender.Send(s.msgs[0])
+	s.Require().False(s.sender.readHeadCaughtUp)
+	s.Require().Equal(readHeadTruncated, s.sender.readHead)
+
+	_, _, err = s.sender.GetCount(1)
+	s.Equal(ErrorTruncated, err)
+}
+
+func (s *InMemorySuite) TestGetCountWithCatchupWithOverflowTruncated() {
+	for i := 0; i < s.maxCap; i++ {
+		s.sender.Send(s.msgs[i])
+	}
+	for i := 0; i < s.maxCap; i++ {
+		msgs, n, err := s.sender.GetCount(1)
+		s.Require().NoError(err)
+		s.Equal(1, n)
+		s.Equal(s.msgs[i], msgs[0])
+	}
+	s.Require().True(s.sender.readHeadCaughtUp)
+
+	for i := 0; i < s.maxCap+1; i++ {
+		s.Require().NotEqual(readHeadTruncated, s.sender.readHead)
+		s.sender.Send(s.msgs[i])
+		s.Require().False(s.sender.readHeadCaughtUp)
+	}
+	s.Require().Equal(readHeadTruncated, s.sender.readHead)
+
+	_, _, err := s.sender.GetCount(1)
+	s.Equal(ErrorTruncated, err)
+}
+
+func (s *InMemorySuite) TestGetCountWithOverflowTruncated() {
+	for i := 0; i < s.maxCap; i++ {
+		s.sender.Send(s.msgs[i])
+	}
+	for i := 0; i < s.maxCap; i++ {
+		msgs, n, err := s.sender.GetCount(1)
+		s.Require().NoError(err)
+		s.Equal(1, n)
+		s.Equal(s.msgs[i], msgs[0])
+	}
+	s.Require().True(s.sender.readHeadCaughtUp)
+
+	for i := 0; i < s.maxCap+1; i++ {
+		s.Require().NotEqual(readHeadTruncated, s.sender.readHead)
+		s.sender.Send(s.msgs[i])
+		s.Require().False(s.sender.readHeadCaughtUp)
+	}
+	s.Require().Equal(readHeadTruncated, s.sender.readHead)
+
+	_, _, err := s.sender.GetCount(1)
+	s.Equal(ErrorTruncated, err)
+}
+
+func (s *InMemorySuite) TestGetCountWithWritesAfterEOF() {
+	s.sender.Send(s.msgs[0])
+	msgs, n, err := s.sender.GetCount(1)
+	s.Require().NoError(err)
+	s.Equal(1, n)
+	s.Equal(s.msgs[0], msgs[0])
+	s.True(s.sender.readHeadCaughtUp)
+	_, _, err = s.sender.GetCount(1)
+	s.Equal(io.EOF, err)
+
+	s.sender.Send(s.msgs[1])
+	s.False(s.sender.readHeadCaughtUp)
+	msgs, n, err = s.sender.GetCount(1)
+	s.Require().NoError(err)
+	s.Equal(1, n)
+	s.Equal(s.msgs[1], msgs[0])
+	s.True(s.sender.readHeadCaughtUp)
+	_, _, err = s.sender.GetCount(1)
+	s.Equal(io.EOF, err)
+}
+
+func (s *InMemorySuite) TestResetRead() {
+	for i := 0; i < s.maxCap-1; i++ {
+		s.sender.Send(s.msgs[i])
+	}
+
+	for i := 0; i < s.maxCap-1; i++ {
+		msgs, n, err := s.sender.GetCount(1)
+		s.Require().NoError(err)
+		s.Require().Equal(1, n)
+		s.Equal(s.msgs[i], msgs[0])
+	}
+	s.True(s.sender.readHeadCaughtUp)
+
+	_, _, err := s.sender.GetCount(1)
+	s.Equal(io.EOF, err)
+
+	s.sender.ResetRead()
+	s.Equal(readHeadNone, s.sender.readHead)
+	s.False(s.sender.readHeadCaughtUp)
+
+	for i := 0; i < s.maxCap-1; i++ {
+		msgs, n, err := s.sender.GetCount(1)
+		s.Require().NoError(err)
+		s.Require().Equal(1, n)
+		s.Equal(s.msgs[i], msgs[0])
+	}
+
+	_, _, err = s.sender.GetCount(1)
+	s.Require().Error(io.EOF, err)
+}
+
+func (s *InMemorySuite) TestGetCountEmptyBuffer() {
+	msgs, n, err := s.sender.GetCount(1)
+	s.Require().Equal(io.EOF, err)
+	s.Zero(n)
+	s.Empty(msgs)
 }
 
 func (s *InMemorySuite) TestGetWithOverflow() {

--- a/send/inmemory_test.go
+++ b/send/inmemory_test.go
@@ -144,7 +144,6 @@ func (s *InMemorySuite) TestGetCountMultipleWithOverflow() {
 	}
 
 	for count := 1; count <= s.maxCap; count++ {
-		// print("***GetCount with count = %d***", count)
 		s.sender.ResetRead()
 		for i := 0; i < s.maxCap; i += count {
 			msgs, n, err := s.sender.GetCount(count)
@@ -157,7 +156,6 @@ func (s *InMemorySuite) TestGetCountMultipleWithOverflow() {
 				remaining = end - start
 			}
 			s.Equal(remaining, n)
-			// print("actual message range: (%d, %d)", start, end)
 			s.Equal(s.msgs[start:end], msgs)
 		}
 		s.True(s.sender.readHeadCaughtUp)

--- a/send/inmemory_test.go
+++ b/send/inmemory_test.go
@@ -280,15 +280,18 @@ func (s *InMemorySuite) TestResetRead() {
 		s.sender.Send(s.msgs[i])
 	}
 
+	var err error
+	var n int
+	var msgs []message.Composer
 	for i := 0; i < s.maxCap-1; i++ {
-		msgs, n, err := s.sender.GetCount(1)
+		msgs, n, err = s.sender.GetCount(1)
 		s.Require().NoError(err)
 		s.Require().Equal(1, n)
 		s.Equal(s.msgs[i], msgs[0])
 	}
 	s.True(s.sender.readHeadCaughtUp)
 
-	_, _, err := s.sender.GetCount(1)
+	_, _, err = s.sender.GetCount(1)
 	s.Equal(io.EOF, err)
 
 	s.sender.ResetRead()
@@ -296,7 +299,7 @@ func (s *InMemorySuite) TestResetRead() {
 	s.False(s.sender.readHeadCaughtUp)
 
 	for i := 0; i < s.maxCap-1; i++ {
-		msgs, n, err := s.sender.GetCount(1)
+		msgs, n, err = s.sender.GetCount(1)
 		s.Require().NoError(err)
 		s.Require().Equal(1, n)
 		s.Equal(s.msgs[i], msgs[0])

--- a/send/slack.go
+++ b/send/slack.go
@@ -186,7 +186,7 @@ func (o *SlackOptions) Validate() error {
 	}
 
 	if !strings.HasPrefix(o.Channel, "#") && !strings.HasPrefix(o.Channel, "@") {
-		return errors.New("Recipient must begin with '#' or '@'")
+		return errors.New("recipient must begin with '#' or '@'")
 	}
 
 	if len(errs) > 0 {

--- a/send/smtp.go
+++ b/send/smtp.go
@@ -329,7 +329,7 @@ func (o *SMTPOptions) sendMail(m message.Composer) error {
 	}
 
 	if err := o.client.Mail(fromAddr.Address); err != nil {
-		return fmt.Errorf("Error establishing mail sender (%s): %+v", fromAddr, err)
+		return fmt.Errorf("error establishing mail sender (%s): %+v", fromAddr, err)
 	}
 
 	var err error


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/MAKE-737

* `GetCount()` allows the in-memory messages to be read oldest to newest in chunks.
* Returns EOF if the read stream has read all the messages so far (but if more is written to the buffer, it won't be EOF anymore).
* Returns ErrorTruncated if the read stream has fallen off the tail end of the fixed-capacity buffer.