### PR TITLE
MAKE-900: run tests on MacOS without compiling test binaries

### DIFF
--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -136,7 +136,7 @@ buildvariants:
   - name: macos
     display_name: macOS
     expansions:
-      build_env: "GOOS=darwin GOROOT=/opt/golang/go1.9 PATH=/opt/golang/go1.9/bin:$PATH DISABLE_COVERAGE=yes"
+      build_env: "GOROOT=/opt/golang/go1.9 PATH=/opt/golang/go1.9/bin:$PATH DISABLE_COVERAGE=yes"
     run_on:
       - macos-1014
       - macos-1014-i7

--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -136,7 +136,7 @@ buildvariants:
   - name: macos
     display_name: macOS
     expansions:
-      build_env: "GOROOT=/opt/golang/go1.9 PATH=/opt/golang/go1.9/bin:$PATH DISABLE_COVERAGE=yes"
+      build_env: "GOOS=darwin GOROOT=/opt/golang/go1.9 PATH=/opt/golang/go1.9/bin:$PATH DISABLE_COVERAGE=yes"
     run_on:
       - macos-1014
       - macos-1014-i7

--- a/makefile
+++ b/makefile
@@ -155,9 +155,11 @@ $(buildDir)/output.lint:$(buildDir)/run-linter .FORCE
 	@./$< --output="$@" --lintArgs='$(lintArgs)' --packages="$(packages)"
 #  targets to process and generate coverage reports
 $(buildDir)/output.%.coverage: .FORCE $(coverDeps)
+	@mkdir -p $(buildDir)
 	go test $(testArgs) -test.coverprofile=$@ | tee $(subst coverage,test,$@)
 	@-[ -f $@ ] && go tool cover -func=$@ | sed 's%$(projectPath)/%%' | column -t
 $(buildDir)/output.%.coverage.html:$(buildDir)/output.%.coverage $(coverDeps)
+	@mkdir -p $(buildDir)
 	go tool cover -html=$< -o $@
 # end test and coverage artifacts
 

--- a/makefile
+++ b/makefile
@@ -143,8 +143,18 @@ $(buildDir)/test.$(name):$(testSrcFiles) $(coverDeps)
 $(buildDir)/race.$(name):$(testSrcFiles)
 	go test -race -c -o $@ ./
 #  targets to run the tests and report the output
+# Due to a bug in go1.9 for MacOS, the test binaries cannot be linked.
+ifeq (${GOOS}, darwin)
+$(buildDir)/output.%.test: .FORCE
+	@mkdir -p $(buildDir)
+	$(testRunEnv) go test $(testArgs) ./$(subst -,/,$*) | tee $@
+$(buildDir)/output.$(name).test: .FORCE
+	$(testRunEnv) go test $(testArgs) ./ | tee $@
+else
 $(buildDir)/output.%.test:$(buildDir)/test.% .FORCE
 	$(testRunEnv) ./$< $(testArgs) 2>&1 | tee $@
+endif
+
 $(buildDir)/output.%.race:$(buildDir)/race.% .FORCE
 	$(testRunEnv) ./$< $(testArgs) 2>&1 | tee $@
 #  targets to generate gotest output from the linter.


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/MAKE-900

Since [linking does not work on go1.9 for MacOS](https://github.com/golang/go/issues/25908), run tests directly instead of compiling/linking test binaries.