### PR TITLE
MAKE-948: fix Windows test compile and panic

### DIFF
--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -152,5 +152,5 @@ buildvariants:
       - windows-64-vs2015-small
       - windows-64-vs2015-large
     expansions:
-      build_env: "GOROOT=c:/golang/go1.9 PATH=c:/golang/go1.9/bin:$PATH DISABLE_COVERAGE=yes"
+      build_env: "GOROOT='C:\\golang\\go1.9' PATH='C:\\golang\\go1.9\\bin':$PATH DISABLE_COVERAGE=yes"
     tasks: [ ".test" ]

--- a/message/golang_info.go
+++ b/message/golang_info.go
@@ -77,8 +77,18 @@ func (s *goStats) mallocs() statRate { return s.getRate(s.mallocCounter.diff()) 
 func (s *goStats) frees() statRate   { return s.getRate(s.freesCounter.diff()) }
 func (s *goStats) gcs() statRate     { return s.getRate(s.gcRate.diff()) }
 
-func (s statRate) float() float64 { return float64(s.Delta) / float64(s.Duration) }
-func (s statRate) int() int64     { return s.Delta / int64(s.Duration) }
+func (s statRate) float() float64 {
+	if s.Duration == 0 {
+		return 0
+	}
+	return float64(s.Delta) / float64(s.Duration)
+}
+func (s statRate) int() int64 {
+	if s.Duration == 0 {
+		return 0
+	}
+	return s.Delta / int64(s.Duration)
+}
 
 // CollectBasicGoStats returns some very basic runtime statistics about the
 // current go process, using runtime.MemStats and


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/MAKE-948

Tests were failing to run because using forward slashes instead of back slashes does not actually set the GOROOT and PATH.
Fixed a panic due to divide by zero in go stats.