### PR TITLE
MAKE-1150: do not close buffered sender and document sender ownership

### DIFF
--- a/send/annotating.go
+++ b/send/annotating.go
@@ -17,7 +17,8 @@ type annotatingSender struct {
 //
 // Calling code should assume that the sender owns the annotations map
 // and it should not attempt to modify that data after calling the
-// sender constructor.
+// sender constructor. Furthermore, since it owns the sender, callin Close on
+// this sender will close the underlying sender.
 //
 // While you can wrap an existing sender with the annotator, changes
 // to the annotating sender (e.g. level, formater, error handler) will

--- a/send/async_group.go
+++ b/send/async_group.go
@@ -22,6 +22,9 @@ type asyncGroupSender struct {
 //
 // This sender does not guarantee ordering of messages, and Send operations may
 // if the underlying senders fall behind the buffer size.
+//
+// The sender takes ownership of the underlying Senders, so closing this sender
+// closes all underlying Senders.
 func NewAsyncGroupSender(ctx context.Context, bufferSize int, senders ...Sender) Sender {
 	s := &asyncGroupSender{
 		senders: senders,
@@ -48,7 +51,7 @@ func NewAsyncGroupSender(ctx context.Context, bufferSize int, senders ...Sender)
 	}
 
 	s.closer = func() error {
-		//s.cancel()
+		s.cancel()
 
 		errs := []string{}
 		for _, sender := range s.senders {

--- a/send/buffered.go
+++ b/send/buffered.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/mongodb/grip/message"
-	"github.com/pkg/errors"
 )
 
 const minInterval = 5 * time.Second
@@ -82,8 +81,8 @@ func (s *bufferedSender) Flush(_ context.Context) error {
 	return nil
 }
 
-// Close writes any buffered messages to the underlying Sender and closes the
-// underlying sender.
+// Close writes any buffered messages to the underlying Sender. This does not
+// close the underlying sender.
 func (s *bufferedSender) Close() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -92,17 +91,11 @@ func (s *bufferedSender) Close() error {
 		return nil
 	}
 
-	defer func() {
-		s.closed = true
-	}()
-
 	s.cancel()
 	if len(s.buffer) > 0 {
 		s.flush()
 	}
-	if err := s.Sender.Close(); err != nil {
-		return errors.Wrap(err, "could not close underlying sender")
-	}
+	s.closed = true
 
 	return nil
 }

--- a/send/buffered.go
+++ b/send/buffered.go
@@ -28,6 +28,10 @@ type bufferedSender struct {
 // If the interval is 0, the constructor sets an interval of 1 minute, and if
 // it is less than 5 seconds, the constructor sets it to 5 seconds. If the
 // size threshold is 0, then the constructor sets a threshold of 100.
+//
+// This Sender does not own the underlying Sender, so users are responsible for
+// closing the underlying Sender if/when it is appropriate to release its
+// resources.
 func NewBufferedSender(sender Sender, interval time.Duration, size int) Sender {
 	if interval == 0 {
 		interval = time.Minute

--- a/send/buffered_test.go
+++ b/send/buffered_test.go
@@ -101,41 +101,40 @@ func TestFlush(t *testing.T) {
 }
 
 func TestBufferedClose(t *testing.T) {
-	for testName, testCase := range map[string]func(t *testing.T, s *InternalSender, bs *bufferedSender){
-		"EmptyBuffer": func(t *testing.T, s *InternalSender, bs *bufferedSender) {
-			assert.Nil(t, bs.Close())
-			assert.True(t, bs.closed)
-			_, ok := s.GetMessageSafe()
-			assert.False(t, ok)
-		},
-		"NonEmptyBuffer": func(t *testing.T, s *InternalSender, bs *bufferedSender) {
-			bs.buffer = append(
-				bs.buffer,
-				message.ConvertToComposer(level.Debug, "message1"),
-				message.ConvertToComposer(level.Debug, "message2"),
-				message.ConvertToComposer(level.Debug, "message3"),
-			)
+	s, err := NewInternalLogger("buffs", LevelInfo{level.Debug, level.Debug})
+	require.NoError(t, err)
 
-			assert.Nil(t, bs.Close())
-			assert.True(t, bs.closed)
-			assert.Empty(t, bs.buffer)
-			msgs, ok := s.GetMessageSafe()
-			require.True(t, ok)
-			assert.Equal(t, "message1\nmessage2\nmessage3", msgs.Message.String())
-		},
-		"NoopWhenClosed": func(t *testing.T, s *InternalSender, bs *bufferedSender) {
-			assert.NoError(t, bs.Close())
-			assert.True(t, bs.closed)
-			assert.NoError(t, bs.Close())
-		},
-	} {
-		t.Run(testName, func(t *testing.T) {
-			s, err := NewInternalLogger("buffs", LevelInfo{Default: level.Debug, Threshold: level.Debug})
-			require.NoError(t, err)
-			bs := newBufferedSender(s, time.Minute, 10)
-			testCase(t, s, bs)
-		})
-	}
+	t.Run("EmptyBuffer", func(t *testing.T) {
+		bs := newBufferedSender(s, time.Minute, 10)
+
+		assert.Nil(t, bs.Close())
+		assert.True(t, bs.closed)
+		_, ok := s.GetMessageSafe()
+		assert.False(t, ok)
+	})
+	t.Run("NonEmptyBuffer", func(t *testing.T) {
+		bs := newBufferedSender(s, time.Minute, 10)
+		bs.buffer = append(
+			bs.buffer,
+			message.ConvertToComposer(level.Debug, "message1"),
+			message.ConvertToComposer(level.Debug, "message2"),
+			message.ConvertToComposer(level.Debug, "message3"),
+		)
+
+		assert.Nil(t, bs.Close())
+		assert.True(t, bs.closed)
+		assert.Empty(t, bs.buffer)
+		msgs, ok := s.GetMessageSafe()
+		require.True(t, ok)
+		assert.Equal(t, "message1\nmessage2\nmessage3", msgs.Message.String())
+	})
+	t.Run("NoopWhenClosed", func(t *testing.T) {
+		bs := newBufferedSender(s, time.Minute, 10)
+
+		assert.NoError(t, bs.Close())
+		assert.True(t, bs.closed)
+		assert.NoError(t, bs.Close())
+	})
 }
 
 func TestIntervalFlush(t *testing.T) {

--- a/send/error_handler.go
+++ b/send/error_handler.go
@@ -22,6 +22,7 @@ func ErrorHandlerFromLogger(l *log.Logger) ErrorHandler {
 	}
 }
 
+// ErrorHandler wraps an existing Sender for sending error messages.
 func ErrorHandlerFromSender(s Sender) ErrorHandler {
 	return func(err error, m message.Composer) {
 		if err == nil {

--- a/send/interface.go
+++ b/send/interface.go
@@ -57,7 +57,8 @@ type Sender interface {
 
 	// If the logging sender holds any resources that require desecration
 	// they should be cleaned up in the Close() method. Close() is called
-	// by the SetSender() method before changing loggers.
+	// by the SetSender() method before changing loggers. Sender implementations
+	// that wrap other Senders may or may not close their underlying Senders.
 	Close() error
 }
 

--- a/send/multi.go
+++ b/send/multi.go
@@ -23,6 +23,9 @@ type multiSender struct {
 //
 // Use the AddToMulti helper to add additioanl senders to one of these
 // multi Sender implementations after construction.
+//
+// The Sender takes ownership of the underlying Senders, so closing this Sender
+// closes all underlying Senders.
 func NewMultiSender(name string, l LevelInfo, senders []Sender) (Sender, error) {
 	if !l.Valid() {
 		return nil, fmt.Errorf("invalid level specification: %+v", l)
@@ -53,6 +56,9 @@ func NewMultiSender(name string, l LevelInfo, senders []Sender) (Sender, error) 
 //
 // Use the AddToMulti helper to add additioanl senders to one of these
 // multi Sender implementations after construction.
+//
+// The Sender takes ownership of the underlying Senders, so closing this Sender
+// closes all underlying Senders.
 func NewConfiguredMultiSender(senders ...Sender) Sender {
 	s := &multiSender{senders: senders, Base: NewBase("")}
 	_ = s.Base.SetLevel(LevelInfo{Default: level.Invalid, Threshold: level.Invalid})

--- a/send/writer.go
+++ b/send/writer.go
@@ -36,7 +36,9 @@ type WriterSender struct {
 // buffered messages) is only whitespace, then it is not sent.
 //
 // If there are any bytes in the buffer when the Close method is
-// called, this sender flushes the buffer.
+// called, this sender flushes the buffer. WriterSender does not own the
+// underlying Sender, so users are responsible for closing the underlying Sender
+// if/when it is appropriate to release its resources.
 func NewWriterSender(s Sender) *WriterSender { return MakeWriterSender(s, s.Level().Default) }
 
 // MakeWriterSender returns an sender interface that also implements
@@ -90,7 +92,7 @@ func (s *WriterSender) doSend() error {
 	}
 }
 
-// Close writes any buffered messages to the underlying Sender. Does
+// Close writes any buffered messages to the underlying Sender. This does
 // not close the underlying sender.
 func (s *WriterSender) Close() error {
 	s.mu.Lock()


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/MAKE-1150

I read the Evergreen code and it relies on the buffered sender not closing the underlying sender. I wrote documentation on which wrappers take ownership of their underlying senders and which ones don't because there's no consistency between any of them.