### PR TITLE
EVG-7251 add generic message/sender

### DIFF
--- a/message/generic.go
+++ b/message/generic.go
@@ -1,0 +1,40 @@
+package message
+
+import (
+	"github.com/mongodb/grip/level"
+)
+
+type genericMessage struct {
+	Base
+	raw         Generic
+	description string
+}
+
+type Generic interface {
+	Send() error
+	Valid() bool
+}
+
+// NewGenericMessage returns a composer for Generic messages
+func NewGenericMessage(p level.Priority, g Generic, description string) Composer {
+	m := &genericMessage{}
+	if err := m.SetPriority(p); err != nil {
+		_ = m.SetPriority(level.Notice)
+	}
+
+	m.raw = g
+	m.description = description
+	return m
+}
+
+func (m *genericMessage) Loggable() bool {
+	return m.raw.Valid()
+}
+
+func (m *genericMessage) String() string {
+	return m.description
+}
+
+func (m *genericMessage) Raw() interface{} {
+	return m.raw
+}

--- a/send/generic.go
+++ b/send/generic.go
@@ -1,0 +1,47 @@
+package send
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/mongodb/grip/message"
+	"github.com/pkg/errors"
+)
+
+type genericLogger struct {
+	*Base
+}
+
+// NewGenericLogger constructs a Sender that executes a function
+func NewGenericLogger(name string, l LevelInfo) (Sender, error) {
+	gl := &genericLogger{
+		Base: NewBase(name),
+	}
+
+	if err := gl.SetLevel(l); err != nil {
+		return nil, err
+	}
+
+	gl.SetName(name)
+
+	fallback := log.New(os.Stdout, "", log.LstdFlags)
+	if err := gl.SetErrorHandler(ErrorHandlerFromLogger(fallback)); err != nil {
+		return nil, err
+	}
+
+	return gl, nil
+}
+
+func (gl *genericLogger) Send(m message.Composer) {
+	if !gl.Level().ShouldLog(m) {
+		return
+	}
+
+	generic := m.Raw().(message.Generic)
+	if err := generic.Send(); err != nil {
+		gl.ErrorHandler()(errors.Wrap(err, "problem processing generic message"), m)
+	}
+}
+
+func (gl *genericLogger) Flush(_ context.Context) error { return nil }


### PR DESCRIPTION
Needed to support changes for EVG-7251 (https://github.com/evergreen-ci/evergreen/pull/3874)
Any type satisfying the `Generic` interface can be a message/sender. This allows application specific logic to be used in a sender, and lets us use a single sender for executing a range of functions.