### PR TITLE
EVG-13798 make internal sender bigger

### DIFF
--- a/send/internal.go
+++ b/send/internal.go
@@ -53,7 +53,7 @@ func NewInternalLogger(name string, l LevelInfo) (*InternalSender, error) {
 func MakeInternalLogger() *InternalSender {
 	s := &InternalSender{
 		Base:   NewBase(""),
-		output: make(chan *InternalMessage, 100),
+		output: make(chan *InternalMessage, 10000),
 	}
 
 	return s


### PR DESCRIPTION
the internal sender deadlocks if you fill up the output channel and try to log more. I apparently wrote a test that logs more than 100 lines