### PR TITLE
EVG-14486: use archlinux-new distros in CI tests

### DIFF
--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -112,8 +112,8 @@ buildvariants:
       GO_BIN_PATH: /opt/golang/go1.13/bin/go
       GOROOT: /opt/golang/go1.13
     run_on:
-      - archlinux-test
-      - archlinux-build
+      - archlinux-new-small
+      - archlinux-new-large
     tasks: [ ".race", ".report" ]
 
   - name: ubuntu1604


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-14486