### PR TITLE
EVG-14482, EVG-14502: upgrade go version and linter

### DIFF
--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -39,8 +39,6 @@ post:
     params:
       files:
         - "gopath/src/github.com/mongodb/grip/build/output.*"
-        - "gopath/src/github.com/mongodb/grip/build/test.*.out"
-        - "gopath/src/github.com/mongodb/grip/build/race.*.out"
   - command: s3.put
     type: system
     params:
@@ -109,30 +107,30 @@ buildvariants:
     display_name: Race Detector (Arch Linux)
     expansions:
       DISABLE_COVERAGE: true
-      GO_BIN_PATH: /opt/golang/go1.13/bin/go
-      GOROOT: /opt/golang/go1.13
+      GO_BIN_PATH: /opt/golang/go1.16/bin/go
+      GOROOT: /opt/golang/go1.16
     run_on:
       - archlinux-new-small
       - archlinux-new-large
     tasks: [ ".race", ".report" ]
 
-  - name: ubuntu1604
-    display_name: Ubuntu 16.04
+  - name: ubuntu
+    display_name: Ubuntu 18.04
     expansions:
       DISABLE_COVERAGE: true
-      GO_BIN_PATH: /opt/golang/go1.13/bin/go
-      GOROOT: /opt/golang/go1.13
+      GO_BIN_PATH: /opt/golang/go1.16/bin/go
+      GOROOT: /opt/golang/go1.16
     run_on:
-      - ubuntu1604-test
-      - ubuntu1604-build
+      - ubuntu1804-small
+      - ubuntu1804-large
     tasks: [ ".test" ]
 
   - name: macos
     display_name: macOS
     expansions:
       DISABLE_COVERAGE: true
-      GO_BIN_PATH: /opt/golang/go1.13/bin/go
-      GOROOT: /opt/golang/go1.13
+      GO_BIN_PATH: /opt/golang/go1.16/bin/go
+      GOROOT: /opt/golang/go1.16
     run_on:
       - macos-1014
     tasks: [ ".test" ]
@@ -146,6 +144,6 @@ buildvariants:
       - windows-64-vs2017-large
     expansions:
       DISABLE_COVERAGE: true
-      GO_BIN_PATH: /cygdrive/c/golang/go1.13/bin/go
-      GOROOT: C;/golang/go1.13
+      GO_BIN_PATH: /cygdrive/c/golang/go1.16/bin/go
+      GOROOT: C:/golang/go1.16
     tasks: [ ".test" ]

--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -26,7 +26,7 @@ functions:
       working_dir: gopath/src/github.com/mongodb/grip
       binary: make
       args: ["${make_args}", "${target}"]
-      add_expansions_to_env: true
+      include_expansions_in_env: ["DISABLE_COVERAGE", "GO_BIN_PATH", "GOROOT"]
       env:
         GOPATH: ${workdir}/gopath
 

--- a/makefile
+++ b/makefile
@@ -22,6 +22,7 @@ endif
 export GOCACHE := $(gocache)
 export GOPATH := $(gopath)
 export GOROOT := $(goroot)
+export GO111MODULE := off
 # end environment setup
 
 # Ensure the build directory exists, since most targets require it.
@@ -30,7 +31,7 @@ $(shell mkdir -p $(buildDir))
 # lint setup targets
 lintDeps := $(buildDir)/golangci-lint $(buildDir)/run-linter
 $(buildDir)/golangci-lint:
-	@curl --retry 10 --retry-max-time 60 -sSfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(buildDir) v1.30.0 >/dev/null 2>&1
+	@curl --retry 10 --retry-max-time 60 -sSfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(buildDir) v1.40.0 >/dev/null 2>&1
 $(buildDir)/run-linter:cmd/run-linter/run-linter.go $(buildDir)/golangci-lint
 	$(gobin) build -o $@ $<
 # end lint setup targets


### PR DESCRIPTION
Jira:
https://jira.mongodb.org/browse/EVG-14482
https://jira.mongodb.org/browse/EVG-14502

* Upgrade go to 1.16.
* Upgrade golangci-lint to 1.40.
* Upgrade Ubuntu to 18.04.