### PR TITLE
EVG-14819: allow wrapped error messages to be used as errors

### DIFF
--- a/message/composer_test.go
+++ b/message/composer_test.go
@@ -102,7 +102,7 @@ func TestPopulatedMessageComposerConstructors(t *testing.T) {
 }
 
 func TestUnpopulatedMessageComposers(t *testing.T) {
-	assert := assert.New(t) // nolint
+	assert := assert.New(t)
 	// map objects to output
 	cases := []Composer{
 		&stringMessage{},
@@ -280,7 +280,7 @@ func TestStackMessages(t *testing.T) {
 	const testMsg = "hello"
 	var stackMsg = "message/composer_test"
 
-	assert := assert.New(t) // nolint
+	assert := assert.New(t)
 	// map objects to output (prefix)
 	cases := map[Composer]string{
 		NewStack(1, testMsg):                testMsg,
@@ -313,7 +313,7 @@ func TestStackMessages(t *testing.T) {
 
 func TestComposerConverter(t *testing.T) {
 	const testMsg = "hello world"
-	assert := assert.New(t) // nolint
+	assert := assert.New(t)
 
 	cases := []interface{}{
 		NewLine(testMsg),
@@ -359,12 +359,11 @@ func TestComposerConverter(t *testing.T) {
 		assert.True(comp.Loggable())
 		assert.True(strings.HasPrefix(comp.String(), out))
 	}
-
 }
 
 func TestJiraMessageComposerConstructor(t *testing.T) {
 	const testMsg = "hello"
-	assert := assert.New(t) // nolint
+	assert := assert.New(t)
 	reporterField := JiraField{Key: "Reporter", Value: "Annie"}
 	assigneeField := JiraField{Key: "Assignee", Value: "Sejin"}
 	typeField := JiraField{Key: "Type", Value: "Bug"}
@@ -383,7 +382,7 @@ func TestJiraMessageComposerConstructor(t *testing.T) {
 }
 
 func TestProcessTreeDoesNotHaveDuplicates(t *testing.T) {
-	assert := assert.New(t) // nolint
+	assert := assert.New(t)
 
 	procs := CollectProcessInfoWithChildren(1)
 	seen := make(map[int32]struct{})
@@ -398,7 +397,7 @@ func TestProcessTreeDoesNotHaveDuplicates(t *testing.T) {
 }
 
 func TestJiraIssueAnnotationOnlySupportsStrings(t *testing.T) {
-	assert := assert.New(t) // nolint
+	assert := assert.New(t)
 
 	m := &jiraMessage{
 		issue: &JiraIssue{},
@@ -413,8 +412,8 @@ type causer interface {
 	Cause() error
 }
 
-func TestErrors(t *testing.T) {
-	for name, cmp := range map[string]Composer{
+func TestErrorComposers(t *testing.T) {
+	for name, cmp := range map[string]ErrorComposer{
 		"Wrapped": WrapError(errors.New("err"), "msg"),
 		"Plain":   NewError(errors.New("err")),
 	} {
@@ -424,16 +423,15 @@ func TestErrors(t *testing.T) {
 				assert.Implements(t, (*causer)(nil), cmp)
 			})
 			t.Run("Value", func(t *testing.T) {
-				assert.Equal(t, cmp.(error).Error(), cmp.String())
+				assert.Equal(t, cmp.Error(), cmp.String())
 			})
 			t.Run("Causer", func(t *testing.T) {
-				cause := errors.Cause(cmp.(error))
+				cause := errors.Cause(cmp)
 				assert.NotEqual(t, cause, cmp)
 			})
 			t.Run("ExtendedFormat", func(t *testing.T) {
 				assert.NotEqual(t, fmt.Sprintf("%+v", cmp), fmt.Sprintf("%v", cmp))
 			})
-
 		})
 	}
 }

--- a/message/error.go
+++ b/message/error.go
@@ -20,14 +20,13 @@ type errorMessage struct {
 	Base       `bson:"metadata" json:"metadata" yaml:"metadata"`
 }
 
-// NewErrorMessage takes an error object and returns a Composer
-// instance that only renders a loggable message when the error is
-// non-nil.
+// NewErrorMessage takes an error object and returns an ErrorComposer instance
+// that only renders a loggable message when the error is non-nil.
 //
-// These composers also implement the error interface and the
-// pkg/errors.Causer interface and so can be passed as errors and used
-// with existing error-wrapping mechanisms.
-func NewErrorMessage(p level.Priority, err error) Composer {
+// These composers also implement the error interface and the pkg/errors.Causer
+// interface and so can be passed as errors and used with existing
+// error-wrapping mechanisms.
+func NewErrorMessage(p level.Priority, err error) ErrorComposer {
 	m := &errorMessage{
 		err: err,
 	}
@@ -36,10 +35,10 @@ func NewErrorMessage(p level.Priority, err error) Composer {
 	return m
 }
 
-// NewError returns an error composer, like NewErrorMessage, but
+// NewError returns an ErrorComposer, like NewErrorMessage, but
 // without the requirement to specify priority, which you may wish to
 // specify directly.
-func NewError(err error) Composer {
+func NewError(err error) ErrorComposer {
 	return &errorMessage{err: err}
 }
 

--- a/message/error_message.go
+++ b/message/error_message.go
@@ -16,7 +16,7 @@ type errorComposerWrap struct {
 
 // NewErrorWrappedComposer provvides a way to construct a log message
 // that annotates an error.
-func NewErrorWrappedComposer(err error, m Composer) Composer {
+func NewErrorWrappedComposer(err error, m Composer) ErrorComposer {
 	return &errorComposerWrap{
 		err:      err,
 		Composer: m,
@@ -28,7 +28,7 @@ func NewErrorWrappedComposer(err error, m Composer) Composer {
 // loggable error message for non-nil errors with a normal formatted
 // message (e.g. fmt.Sprintf). These messages only log if the error is
 // non-nil.
-func NewErrorWrapMessage(p level.Priority, err error, base string, args ...interface{}) Composer {
+func NewErrorWrapMessage(p level.Priority, err error, base string, args ...interface{}) ErrorComposer {
 	return NewErrorWrappedComposer(err, NewFormattedMessage(p, base, args...))
 }
 
@@ -37,19 +37,19 @@ func NewErrorWrapMessage(p level.Priority, err error, base string, args ...inter
 // message for non-nil errors with a normal formatted message
 // (e.g. fmt.Sprintf). These messages only log if the error is
 // non-nil.
-func NewErrorWrap(err error, base string, args ...interface{}) Composer {
+func NewErrorWrap(err error, base string, args ...interface{}) ErrorComposer {
 	return NewErrorWrappedComposer(err, NewFormatted(base, args...))
 }
 
 // WrapError wraps an error and creates a composer converting the
 // argument into a composer in the same manner as the front end logging methods.
-func WrapError(err error, m interface{}) Composer {
+func WrapError(err error, m interface{}) ErrorComposer {
 	return NewErrorWrappedComposer(err, ConvertToComposer(level.Priority(0), m))
 }
 
 // WrapErrorf wraps an error and creates a composer using a
 // Sprintf-style formated composer.
-func WrapErrorf(err error, msg string, args ...interface{}) Composer {
+func WrapErrorf(err error, msg string, args ...interface{}) ErrorComposer {
 	return NewErrorWrappedComposer(err, NewFormatted(msg, args...))
 }
 

--- a/message/interface.go
+++ b/message/interface.go
@@ -36,6 +36,12 @@ type Composer interface {
 	SetPriority(level.Priority) error
 }
 
+// ErrorComposer defines an interface to a Composer that also includes an error.
+type ErrorComposer interface {
+	Composer
+	Error() string
+}
+
 // ConvertToComposer can coerce unknown objects into Composer
 // instances, as possible. This method will override the priority of
 // composers set to it.


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-14819

Allow `message.Composer` types that also wrap errors to implement the `error` interface. This is convenient for wrapping an error in more context, but still letting it be used as an `error` type. For example:
```go
message.WrapError(err, message.Fields{
    "message": "<some message>",
    "job": "<job_id>",
})
```
can be used as either a `message.Composer` or an `error`.