### PR TITLE
EVG-15479, EVG-15495: remove GO_BIN_PATH and fix linter PATH

### DIFF
--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -26,7 +26,7 @@ functions:
       working_dir: gopath/src/github.com/mongodb/grip
       binary: make
       args: ["${make_args}", "${target}"]
-      include_expansions_in_env: ["DISABLE_COVERAGE", "GO_BIN_PATH", "GOROOT"]
+      include_expansions_in_env: ["DISABLE_COVERAGE", "GOROOT", "RACE_DETECTOR"]
       env:
         GOPATH: ${workdir}/gopath
 
@@ -92,10 +92,6 @@ tasks:
     name: test
 
   - <<: *run-build
-    tags: ["race"]
-    name: race
-
-  - <<: *run-build
     tags: ["test"]
     name: benchmark-send
 
@@ -107,12 +103,21 @@ buildvariants:
     display_name: Race Detector (Arch Linux)
     expansions:
       DISABLE_COVERAGE: true
-      GO_BIN_PATH: /opt/golang/go1.16/bin/go
+      GOROOT: /opt/golang/go1.16
+      RACE_DETECTOR: true
+    run_on:
+      - archlinux-new-small
+      - archlinux-new-large
+    tasks: [ ".test" ]
+
+  - name: lint
+    display_name: Lint
+    expansions:
       GOROOT: /opt/golang/go1.16
     run_on:
       - archlinux-new-small
       - archlinux-new-large
-    tasks: [ ".race", ".report" ]
+    tasks: [ ".report" ]
 
   - name: ubuntu
     display_name: Ubuntu 18.04
@@ -129,7 +134,6 @@ buildvariants:
     display_name: macOS
     expansions:
       DISABLE_COVERAGE: true
-      GO_BIN_PATH: /opt/golang/go1.16/bin/go
       GOROOT: /opt/golang/go1.16
     run_on:
       - macos-1014
@@ -144,6 +148,5 @@ buildvariants:
       - windows-64-vs2017-large
     expansions:
       DISABLE_COVERAGE: true
-      GO_BIN_PATH: /cygdrive/c/golang/go1.16/bin/go
       GOROOT: C:/golang/go1.16
     tasks: [ ".test" ]

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-# project configuration
+# start project configuration
 name := grip
 buildDir := build
 packages := recovery logging message send slogger $(name)
@@ -7,141 +7,113 @@ projectPath := $(orgPath)/$(name)
 # end project configuration
 
 # start environment setup
-gobin := $(GO_BIN_PATH)
-ifeq (,$(gobin))
-	gobin := go
+gobin := go
+ifneq (,$(GOROOT))
+gobin := $(GOROOT)/bin/go
 endif
-gocache := $(abspath $(buildDir)/.cache)
-gopath := $(GOPATH)
-goroot := $(GOROOT)
+
 ifeq ($(OS),Windows_NT)
-	gocache := $(shell cygpath -m $(gocache))
-	gopath := $(shell cygpath -m $(gopath))
-	goroot := $(shell cygpath -m $(goroot))
+gobin := $(shell cygpath $(gobin))
+export GOCACHE := $(shell cygpath -m $(abspath $(buildDir)/.cache))
+export GOLANGCI_LINT_CACHE := $(shell cygpath -m $(abspath $(buildDir)/.lint-cache))
+export GOPATH := $(shell cygpath -m $(GOPATH))
+export GOROOT := $(shell cygpath -m $(GOROOT))
 endif
-export GOCACHE := $(gocache)
-export GOPATH := $(gopath)
-export GOROOT := $(goroot)
+
 export GO111MODULE := off
 # end environment setup
 
 # Ensure the build directory exists, since most targets require it.
 $(shell mkdir -p $(buildDir))
 
-# lint setup targets
+.DEFAULT_GOAL := compile
+
+# start lint setup targets
 lintDeps := $(buildDir)/golangci-lint $(buildDir)/run-linter
 $(buildDir)/golangci-lint:
 	@curl --retry 10 --retry-max-time 60 -sSfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(buildDir) v1.40.0 >/dev/null 2>&1
-$(buildDir)/run-linter:cmd/run-linter/run-linter.go $(buildDir)/golangci-lint
+$(buildDir)/run-linter: cmd/run-linter/run-linter.go $(buildDir)/golangci-lint
 	$(gobin) build -o $@ $<
 # end lint setup targets
-#
-######################################################################
-##
-## Everything below this point is generic, and does not contain
-## project specific configuration. (with one noted case in the "build"
-## target for library-only projects)
-##
-######################################################################
 
-
-# start dependency installation tools
-#   implementation details for being able to lazily install dependencies
+# start package and file lists
 testOutput := $(foreach target,$(packages),$(buildDir)/output.$(target).test)
-raceOutput := $(foreach target,$(packages),$(buildDir)/output.$(target).race)
+lintOutput := $(foreach target,$(packages),$(buildDir)/output.$(target).lint)
 coverageOutput := $(foreach target,$(packages),$(buildDir)/output.$(target).coverage)
 coverageHtmlOutput := $(foreach target,$(packages),$(buildDir)/output.$(target).coverage.html)
-# end dependency installation tools
+.PRECIOUS: $(coverageOutput) $(coverageHtmlOutput) $(lintOutput) $(testOutput)
+# end package and file lists
 
-
-# userfacing targets for basic build and development operations
-lint:$(foreach target,$(packages),lint-$(target))
-build: $(gopath)/src/$(projectPath)
+# start basic development targets
+compile: 
 	$(gobin) build $(subst $(name),,$(subst -,/,$(foreach pkg,$(packages),./$(pkg))))
-test:$(testOutput)
-race:$(raceOutput)
-coverage:$(coverageOutput)
-coverage-html:$(coverageHtmlOutput)
-phony := lint build build-race race test benchmark-send coverage coverage-html
-.PRECIOUS:$(testOutput) $(raceOutput) $(coverageOutput) $(coverageHtmlOutput)
-.PRECIOUS:$(foreach target,$(packages),$(buildDir)/output.$(target).test)
-.PRECIOUS:$(foreach target,$(packages),$(buildDir)/output.$(target).lint)
-# end front-ends
-
-
-# implementation details for building the binary and creating a
-# convienent link in the working directory
-# convenience targets for running tests and coverage tasks on a
-# specific package.
-makeArgs := --no-print-directory
-test-%:$(buildDir)/output.%.test
-	@grep -s -q -e "^PASS" $<
+test: $(testOutput)
+lint: $(lintOutput)
+coverage: $(coverageOutput)
+coverage-html: $(coverageHtmlOutput)
 benchmark-send:
 	$(gobin) test -v -bench=$(if $(RUN_BENCH),$(RUN_BENCH),BenchmarkAllSenders) ./send/ ./send/benchmark/ -run=^^$$
-coverage-%:$(buildDir)/output.%.coverage
-	@grep -s -q -e "^PASS" $(buildDir)/output.$*.test
-html-coverage-%:$(buildDir)/output.%.coverage $(buildDir)/output.%.coverage.html
-	@grep -s -q -e "^PASS" $(buildDir)/output.$*.test
-lint-%:$(buildDir)/output.%.lint
-	@grep -v -s -q "^--- FAIL" $<
-# end convienence targets
+phony := compile lint test coverage coverage-html benchmark-send
 
+# start convenience targets for running tests and coverage tasks on a
+# specific package.
+test-%: $(buildDir)/output.%.test
+	@grep -s -q -e "^PASS" $<
+coverage-%: $(buildDir)/output.%.coverage
+	@grep -s -q -e "^PASS" $(buildDir)/output.$*.test
+html-coverage-%: $(buildDir)/output.%.coverage $(buildDir)/output.%.coverage.html
+	@grep -s -q -e "^PASS" $(buildDir)/output.$*.test
+lint-%: $(buildDir)/output.%.lint
+	@grep -v -s -q "^--- FAIL" $<
+# end convenience targets
+# end basic development targets
 
 # start test and coverage artifacts
-#    tests have compile and runtime deps. This varable has everything
-#    that the tests actually need to run. (The "build" target is
-#    intentional and makes these targets rerun as expected.)
-testArgs := -test.v --test.timeout=5m
+testArgs := -v
 ifneq (,$(RUN_TEST))
-testArgs += -test.run='$(RUN_TEST)'
+testArgs += -run='$(RUN_TEST)'
 endif
-ifneq (,$(RUN_CASE))
-testArgs += -testify.m='$(RUN_CASE)'
+ifneq (,$(RACE_DETECTOR))
+testArgs += -race
+endif
+ifeq (,$(DISABLE_COVERAGE))
+testArgs += -cover
 endif
 $(buildDir)/output.%.test: .FORCE
-	$(gobin) test $(if $(DISABLE_COVERAGE),,-covermode=count) $(testArgs) ./$(subst -,/,$*) | tee $@
-$(buildDir)/output.$(name).test: .FORCE
-	$(gobin) test $(testArgs) ./ | tee $@
-
-$(buildDir)/output.%.race: .FORCE
-	$(gobin) test -race $(testArgs) ./$(subst -,/,$*) 2>&1 | tee $@
-$(buildDir)/output.$(name).race: .FORCE
-	$(gobin) test -race $(testArgs) ./ 2>&1 | tee $@
-#  targets to generate gotest output from the linter.
-# We have to handle the PATH specially for CI, because if the PATH has a different version of Go in it, it'll break.
-$(buildDir)/output.%.lint:$(buildDir)/run-linter .FORCE
-	@$(if $(GO_BIN_PATH), PATH="$(shell dirname $(GO_BIN_PATH)):$(PATH)") ./$< --output=$@ --lintBin="$(buildDir)/golangci-lint" --packages='$*'
-#  targets to process and generate coverage reports
+	$(gobin) test $(testArgs) ./$(if $(subst $(name),,$*),$(subst -,/,$*),) | tee $@
 $(buildDir)/output.%.coverage: .FORCE
-	$(gobin) test $(testArgs) -test.coverprofile=$@ | tee $(subst coverage,test,$@)
+	$(gobin) test $(testArgs) -covermode=count -coverprofile=$@ | tee $(buildDir)/output.$*.test
 	@-[ -f $@ ] && $(gobin) tool cover -func=$@ | sed 's%$(projectPath)/%%' | column -t
-$(buildDir)/output.%.coverage.html:$(buildDir)/output.%.coverage
+$(buildDir)/output.%.coverage.html: $(buildDir)/output.%.coverage
 	$(gobin) tool cover -html=$< -o $@
+
+ifneq (go,$(gobin))
+# We have to handle the PATH specially for linting in CI, because if the PATH has a different version of the Go
+# binary in it, the linter won't work properly.
+lintEnvVars := PATH="$(shell dirname $(gobin)):$(PATH)"
+endif
+$(buildDir)/output.%.lint: $(buildDir)/run-linter .FORCE
+	@$(lintEnvVars) ./$< --output=$@ --lintBin=$(buildDir)/golangci-lint --packages='$*'
 # end test and coverage artifacts
 
-
 # start vendoring configuration
-#    begin with configuration of dependencies
 vendor-clean:
 	rm -rf vendor/github.com/mattn/go-xmpp/_example/
 	rm -rf vendor/github.com/bluele/slack/examples/
 	find vendor/ -name "*.go" | xargs gofmt -w -r '"golang.org/x/net/context" -> "context"'
 	find vendor/github.com/shirou/gopsutil/ -name "*.go" | xargs -n 1 gofmt -w || true
 	find vendor/ -name "*.gif" -o -name "*.gz" -o -name "*.png" -o -name "*.ico" -o -name "*.dat" -o -name "*testdata" | xargs rm -fr
-#   add phony targets
 phony += vendor-clean
-# end vendoring tooling configuration
+# end vendoring configuration
 
-
-# clean and other utility targets
+# start cleanup targets
 clean:
-	rm -rf $(name) $(lintDeps)
+	rm -rf $(buildDir)
 clean-results:
 	$(buildDir)/output.*
-phony += clean
-# end dependency targets
-
+phony += clean clean-results
+# end cleanup targets
 
 # configure phony targets
 .FORCE:
-.PHONY:$(phony) .FORCE
+.PHONY: $(phony) .FORCE


### PR DESCRIPTION
Jira:
https://jira.mongodb.org/browse/EVG-15479
https://jira.mongodb.org/browse/EVG-15495

* Remove GO_BIN_PATH. CI tests now depend on GOROOT to tell them which Go version to use and which Go binary to use.
* Set the GOLANGCI_LINT_CACHE, which is used to control where golangci-lint caches information. By default, golangci-lint will use the user's cache directory (usually in the home directory). This prevents the CI linter from writing outside of the working directory.
* Fix setting the PATH variable for the linter.
* Clean up and standardize the makefile.