### PR TITLE
EVG-15449: specify timezone for Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
     schedule:
       interval: monthly
       time: "10:00"
+      timezone: "UTC"
     open-pull-requests-limit: 99
     commit-message:
       prefix: "CHORE: "


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15449

Set the timezone to UTC. The docs don't say what the "default" timezone is (I assume it's UTC), so just set it explicitly to be safe.