### PR TITLE
EVG-16236 drop messages that come in faster than we can process them

### DIFF
--- a/send/benchmark/harness.go
+++ b/send/benchmark/harness.go
@@ -49,7 +49,7 @@ func messageCounts() []int {
 func senderCases() map[string]benchCase {
 	return map[string]benchCase{
 		"BufferedSender":      bufferedSenderCase,
-		"bufferedAsyncSender": bufferedAsyncSenderCase,
+		"BufferedAsyncSender": bufferedAsyncSenderCase,
 		"CallSiteFileLogger":  callSiteFileLoggerCase,
 		"FileLogger":          fileLoggerCase,
 		"InMemorySender":      inMemorySenderCase,

--- a/send/benchmark/harness.go
+++ b/send/benchmark/harness.go
@@ -78,7 +78,11 @@ func bufferedSenderCase(ctx context.Context, tm TimerManager, iters int, size in
 	if err != nil {
 		return err
 	}
-	s := send.NewBufferedSender(context.Background(), internal, send.BufferedSenderOptions{FlushInterval: 5 * time.Second, BufferSize: 100000})
+	s, err := send.NewBufferedSender(context.Background(), internal, send.BufferedSenderOptions{FlushInterval: 5 * time.Second, BufferSize: 100000})
+	if err != nil {
+		return err
+	}
+
 	defer func(s send.Sender) {
 		if e := s.Close(); e != nil {
 			err = e

--- a/send/benchmark/harness.go
+++ b/send/benchmark/harness.go
@@ -78,8 +78,7 @@ func bufferedSenderCase(ctx context.Context, tm TimerManager, iters int, size in
 	if err != nil {
 		return err
 	}
-	minBufferLength := 5 * time.Second
-	s := send.NewBufferedSender(internal, minBufferLength, 100000)
+	s := send.NewBufferedSender(context.Background(), internal, send.BufferedSenderOptions{FlushInterval: 5 * time.Second, BufferSize: 100000})
 	defer func(s send.Sender) {
 		if e := s.Close(); e != nil {
 			err = e

--- a/send/benchmark/harness.go
+++ b/send/benchmark/harness.go
@@ -99,7 +99,7 @@ func bufferedAsyncSenderCase(ctx context.Context, tm TimerManager, iters int, si
 	if err != nil {
 		return err
 	}
-	s, err := send.NewBufferedAsyncSender(context.Background(), internal, send.BufferedAsyncSenderOptions{FlushInterval: 5 * time.Second, BufferSize: 100000})
+	s, err := send.NewBufferedAsyncSender(ctx, internal, send.BufferedAsyncSenderOptions{FlushInterval: 5 * time.Second, BufferSize: 100000})
 	if err != nil {
 		return err
 	}

--- a/send/benchmark/harness.go
+++ b/send/benchmark/harness.go
@@ -79,7 +79,7 @@ func bufferedSenderCase(ctx context.Context, tm TimerManager, iters int, size in
 	if err != nil {
 		return err
 	}
-	s := send.NewBufferedSender(internal, 5*time.Second, 100000)
+	s, err := send.NewBufferedSender(ctx, internal, send.BufferedSenderOptions{FlushInterval: 5 * time.Second, BufferSize: 100000})
 	if err != nil {
 		return err
 	}
@@ -99,7 +99,11 @@ func bufferedAsyncSenderCase(ctx context.Context, tm TimerManager, iters int, si
 	if err != nil {
 		return err
 	}
-	s, err := send.NewBufferedAsyncSender(ctx, internal, send.BufferedAsyncSenderOptions{FlushInterval: 5 * time.Second, BufferSize: 100000})
+	opts := send.BufferedAsyncSenderOptions{}
+	opts.FlushInterval = 5 * time.Second
+	opts.BufferSize = 100000
+
+	s, err := send.NewBufferedAsyncSender(ctx, internal, opts)
 	if err != nil {
 		return err
 	}

--- a/send/buffered.go
+++ b/send/buffered.go
@@ -2,134 +2,159 @@ package send
 
 import (
 	"context"
-	"sync"
+	"errors"
 	"time"
 
 	"github.com/mongodb/grip/message"
 )
 
-const minInterval = 5 * time.Second
+const (
+	minInterval          = 5 * time.Second
+	defaultFlushInterval = time.Minute
+	defaultBufferSize    = 100
+
+	incomingBufferFactor = 10
+)
 
 type bufferedSender struct {
-	mu        sync.Mutex
-	cancel    context.CancelFunc
-	buffer    []message.Composer
-	size      int
-	lastFlush time.Time
-	closed    bool
+	ctx         context.Context
+	cancel      context.CancelFunc
+	buffer      []message.Composer
+	opts        BufferedSenderOptions
+	flushTicker *time.Ticker
+	incoming    chan message.Composer
+	needsFlush  chan bool
 
 	Sender
 }
 
 // NewBufferedSender provides a Sender implementation that wraps an existing
-// Sender sending messages in batches, on a specified buffer size or after an
-// interval has passed.
+// Sender sending messages in batches. Messages are automatically flushed
+// when the buffer reaches a specified size or or after a specified interval
+// has passed.
 //
-// If the interval is 0, the constructor sets an interval of 1 minute, and if
-// it is less than 5 seconds, the constructor sets it to 5 seconds. If the
-// size threshold is 0, then the constructor sets a threshold of 100.
+// If the flushInterval is 0, the constructor sets an flushInterval of 1 minute.
+// If the flushInterval is less than 5 seconds, the constructor sets it to 5 seconds.
+// If the bufferSize threshold is 0, the constructor sets a threshold of 100.
 //
 // This Sender does not own the underlying Sender, so users are responsible for
 // closing the underlying Sender if/when it is appropriate to release its
 // resources.
-func NewBufferedSender(sender Sender, interval time.Duration, size int) Sender {
-	if interval == 0 {
-		interval = time.Minute
-	} else if interval < minInterval {
-		interval = minInterval
-	}
+func NewBufferedSender(ctx context.Context, sender Sender, opts BufferedSenderOptions) Sender {
+	opts.validate()
 
-	if size <= 0 {
-		size = 100
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(ctx)
 	s := &bufferedSender{
-		Sender: sender,
-		cancel: cancel,
-		buffer: []message.Composer{},
-		size:   size,
+		Sender:     sender,
+		ctx:        ctx,
+		cancel:     cancel,
+		opts:       opts,
+		buffer:     make([]message.Composer, 0, opts.BufferSize),
+		needsFlush: make(chan bool, 1),
+		incoming:   make(chan message.Composer, incomingBufferFactor*opts.BufferSize),
 	}
 
-	go s.intervalFlush(ctx, interval)
+	go s.consumer()
 
 	return s
 }
 
+type BufferedSenderOptions struct {
+	FlushInterval time.Duration
+	BufferSize    int
+}
+
+func (opts *BufferedSenderOptions) validate() {
+	if opts.FlushInterval == 0 {
+		opts.FlushInterval = time.Minute
+	} else if opts.FlushInterval < minInterval {
+		opts.FlushInterval = minInterval
+	}
+
+	if opts.BufferSize <= 0 {
+		opts.BufferSize = defaultBufferSize
+	}
+}
+
 func (s *bufferedSender) Send(msg message.Composer) {
+	if s.ctx.Err() != nil {
+		return
+	}
+
 	if !s.Level().ShouldLog(msg) {
 		return
 	}
 
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	if s.closed {
-		return
-	}
-
-	s.buffer = append(s.buffer, msg)
-	if len(s.buffer) >= s.size {
-		s.flush()
+	select {
+	case s.incoming <- msg:
+	default:
+		s.ErrorHandler()(errors.New("the message has been dropped"), msg)
 	}
 }
 
 func (s *bufferedSender) Flush(_ context.Context) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	if !s.closed {
-		s.flush()
-	}
-
-	return nil
-}
-
-// Close writes any buffered messages to the underlying Sender. This does not
-// close the underlying sender.
-func (s *bufferedSender) Close() error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	if s.closed {
+	if s.ctx.Err() != nil {
 		return nil
 	}
 
-	s.cancel()
-	if len(s.buffer) > 0 {
-		s.flush()
+	if len(s.needsFlush) == 0 {
+		s.needsFlush <- true
 	}
-	s.closed = true
 
 	return nil
 }
 
-func (s *bufferedSender) intervalFlush(ctx context.Context, interval time.Duration) {
-	timer := time.NewTimer(interval)
-	defer timer.Stop()
+// Close writes any buffered messages to the underlying Sender
+// and prevents new messages from being accepted.
+// This does not close the underlying sender.
+func (s *bufferedSender) Close() error {
+	s.cancel()
+
+	return nil
+}
+
+func (s *bufferedSender) consumer() {
+	s.flushTicker = time.NewTicker(s.opts.FlushInterval)
+	defer s.flushTicker.Stop()
 
 	for {
 		select {
-		case <-ctx.Done():
+		case <-s.ctx.Done():
+			s.flushAll()
 			return
-		case <-timer.C:
-			s.mu.Lock()
-			if len(s.buffer) > 0 && time.Since(s.lastFlush) >= interval {
-				s.flush()
-			}
-			s.mu.Unlock()
-			_ = timer.Reset(interval)
+		case msg := <-s.incoming:
+			s.addToBuffer(msg)
+		case <-s.needsFlush:
+			s.flushAll()
+		case <-s.flushTicker.C:
+			s.flush()
 		}
+	}
+}
+
+func (s *bufferedSender) flushAll() {
+	for len(s.incoming) > 0 {
+		msg := <-s.incoming
+		s.addToBuffer(msg)
+	}
+
+	s.flush()
+}
+
+func (s *bufferedSender) addToBuffer(msg message.Composer) {
+	s.buffer = append(s.buffer, msg)
+	if len(s.buffer) == cap(s.buffer) {
+		s.flush()
 	}
 }
 
 func (s *bufferedSender) flush() {
 	if len(s.buffer) == 1 {
 		s.Sender.Send(s.buffer[0])
-	} else {
+	} else if len(s.buffer) > 1 {
 		s.Sender.Send(message.NewGroupComposer(s.buffer))
 	}
 
-	s.buffer = []message.Composer{}
-	s.lastFlush = time.Now()
+	s.flushTicker.Reset(s.opts.FlushInterval)
+	s.buffer = s.buffer[:0]
 }

--- a/send/buffered.go
+++ b/send/buffered.go
@@ -134,8 +134,7 @@ func (s *bufferedSender) consumer() {
 
 func (s *bufferedSender) flushAll() {
 	for len(s.incoming) > 0 {
-		msg := <-s.incoming
-		s.addToBuffer(msg)
+		s.addToBuffer(<-s.incoming)
 	}
 
 	s.flush()

--- a/send/buffered_async.go
+++ b/send/buffered_async.go
@@ -1,0 +1,176 @@
+package send
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/mongodb/grip/message"
+)
+
+const (
+	minBufferedAsyncFlushInterval     = 5 * time.Second
+	defaultBufferedAsyncFlushInterval = time.Minute
+	defaultBufferedAsyncBufferSize    = 100
+
+	incomingBufferFactor = 10
+)
+
+type bufferedAsyncSender struct {
+	cancel     context.CancelFunc
+	buffer     []message.Composer
+	opts       BufferedAsyncSenderOptions
+	flushTimer *time.Timer
+	incoming   chan message.Composer
+	needsFlush chan bool
+
+	Sender
+}
+
+// NewBufferedAsyncSender provides a Sender implementation that wraps an existing
+// Sender sending messages in batches. Messages are automatically flushed
+// when the buffer reaches a specified size or or after a specified interval
+// has passed. Because the sender is async calls to Send and Flush will return
+// immediately even if the buffer is full and even before messages have been sent.
+//
+// This Sender does not own the underlying Sender, so users are responsible for
+// closing the underlying Sender if/when it is appropriate to release its
+// resources.
+func NewBufferedAsyncSender(ctx context.Context, sender Sender, opts BufferedAsyncSenderOptions) (Sender, error) {
+	if err := opts.validate(); err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	s := &bufferedAsyncSender{
+		Sender:     sender,
+		cancel:     cancel,
+		opts:       opts,
+		buffer:     make([]message.Composer, 0, opts.BufferSize),
+		needsFlush: make(chan bool, 1),
+		incoming:   make(chan message.Composer, incomingBufferFactor*opts.BufferSize),
+	}
+
+	go s.processMessages(ctx)
+
+	return s, nil
+}
+
+// BufferedAsyncSenderOptions configure the buffered sender.
+// If FlushInterval is less than 5 seconds, it is set to 5 seconds.
+// If BufferSize threshold is 0, it is set to 100.
+type BufferedAsyncSenderOptions struct {
+	// FlushInterval is the interval to automatically flush the buffer.
+	// 1 minute by default.
+	// The minimum interval is 5 seconds.
+	// If an interval of less than 5 seconds is specified it is set to 5 seconds.
+	FlushInterval time.Duration
+	// BufferSize is the threshold at which the buffer is flushed.
+	// 100 by default.
+	BufferSize int
+}
+
+func (opts *BufferedAsyncSenderOptions) validate() error {
+	if opts.FlushInterval < 0 {
+		return errors.New("FlushInterval can not be negative")
+	}
+	if opts.BufferSize < 0 {
+		return errors.New("BufferSize can not be negative")
+	}
+
+	if opts.FlushInterval == 0 {
+		opts.FlushInterval = defaultBufferedAsyncFlushInterval
+	} else if opts.FlushInterval < minInterval {
+		opts.FlushInterval = minInterval
+	}
+
+	if opts.BufferSize < 0 {
+		opts.BufferSize = defaultBufferedAsyncBufferSize
+	}
+
+	return nil
+}
+
+// Send puts the message in the buffer to be flushed on the next flush interval
+// or when the buffer threshold is surpassed. It will return immediately and not block
+// on the underlying sender sending the messages.
+// If messages are received faster than the underlying sender can process them new messages
+// will be dropped.
+func (s *bufferedAsyncSender) Send(msg message.Composer) {
+	if !s.Level().ShouldLog(msg) {
+		return
+	}
+
+	select {
+	case s.incoming <- msg:
+	default:
+		if errHandler := s.ErrorHandler(); errHandler != nil {
+			errHandler(errors.New("the message was dropped because the buffer was full"), msg)
+		}
+	}
+}
+
+// Flush signals that whatever is in the buffer should be flushed
+// to the underlying sender. Flush returns immediately and the flush happens
+// asynchronously.
+func (s *bufferedAsyncSender) Flush(_ context.Context) error {
+	select {
+	case s.needsFlush <- true:
+	default:
+	}
+
+	return nil
+}
+
+// Close writes any buffered messages to the underlying Sender
+// and signals that the sender should stop processing additional messages.
+func (s *bufferedAsyncSender) Close() error {
+	s.cancel()
+
+	return nil
+}
+
+func (s *bufferedAsyncSender) processMessages(ctx context.Context) {
+	s.flushTimer = time.NewTimer(s.opts.FlushInterval)
+	defer s.flushTimer.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			s.flushAll()
+			return
+		case msg := <-s.incoming:
+			s.addToBuffer(msg)
+		case <-s.needsFlush:
+			s.flushAll()
+		case <-s.flushTimer.C:
+			s.flush()
+		}
+	}
+}
+
+func (s *bufferedAsyncSender) flushAll() {
+	for len(s.incoming) > 0 {
+		s.addToBuffer(<-s.incoming)
+	}
+
+	s.flush()
+}
+
+func (s *bufferedAsyncSender) addToBuffer(msg message.Composer) {
+	s.buffer = append(s.buffer, msg)
+	if len(s.buffer) == cap(s.buffer) {
+		s.flush()
+	}
+}
+
+func (s *bufferedAsyncSender) flush() {
+	if len(s.buffer) == 1 {
+		s.Sender.Send(s.buffer[0])
+	} else if len(s.buffer) > 1 {
+		s.Sender.Send(message.NewGroupComposer(s.buffer))
+	}
+
+	s.flushTimer.Reset(s.opts.FlushInterval)
+	s.buffer = s.buffer[:0]
+}

--- a/send/buffered_async.go
+++ b/send/buffered_async.go
@@ -155,7 +155,8 @@ func (s *bufferedAsyncSender) processMessages() {
 }
 
 func (s *bufferedAsyncSender) flushAll() {
-	for len(s.incoming) > 0 {
+	lenIncoming := len(s.incoming)
+	for x := 0; x < lenIncoming; x++ {
 		s.addToBuffer(<-s.incoming)
 	}
 

--- a/send/buffered_async.go
+++ b/send/buffered_async.go
@@ -11,10 +11,7 @@ import (
 )
 
 const (
-	minBufferedAsyncFlushInterval     = 5 * time.Second
-	defaultBufferedAsyncFlushInterval = time.Minute
-	defaultBufferedAsyncBufferSize    = 100
-	defaultIncomingBufferFactor       = 10
+	defaultIncomingBufferFactor = 10
 )
 
 type bufferedAsyncSender struct {
@@ -66,14 +63,7 @@ func NewBufferedAsyncSender(ctx context.Context, sender Sender, opts BufferedAsy
 
 // BufferedAsyncSenderOptions configure the buffered asynchronous sender.
 type BufferedAsyncSenderOptions struct {
-	// FlushInterval is the maximum duration between flushes. The buffer will automatically
-	// flush if it hasn't flushed within the past FlushInterval.
-	// FlushInterval is 1 minute by default. The minimum interval is 5 seconds.
-	// If an interval of less than 5 seconds is specified it is set to 5 seconds.
-	FlushInterval time.Duration
-	// BufferSize is the threshold at which the buffer is flushed.
-	// The size is 100 by default.
-	BufferSize int
+	BufferedSenderOptions
 	// IncomingBufferFactor is multiplied with BufferSize to determine the number of
 	// messages the sender can hold in waiting. Incoming messages are dropped if they're sent
 	// while the number of messages waiting to be written to the buffer exceeds
@@ -82,24 +72,12 @@ type BufferedAsyncSenderOptions struct {
 }
 
 func (opts *BufferedAsyncSenderOptions) validate() error {
-	if opts.FlushInterval < 0 {
-		return errors.New("FlushInterval can not be negative")
+	if err := opts.BufferedSenderOptions.validate(); err != nil {
+		return err
 	}
-	if opts.BufferSize < 0 {
-		return errors.New("BufferSize can not be negative")
-	}
+
 	if opts.IncomingBufferFactor < 0 {
 		return errors.New("IncomingBufferFactor can not be negative")
-	}
-
-	if opts.FlushInterval == 0 {
-		opts.FlushInterval = defaultBufferedAsyncFlushInterval
-	} else if opts.FlushInterval < minInterval {
-		opts.FlushInterval = minInterval
-	}
-
-	if opts.BufferSize == 0 {
-		opts.BufferSize = defaultBufferedAsyncBufferSize
 	}
 
 	if opts.IncomingBufferFactor == 0 {

--- a/send/buffered_async_test.go
+++ b/send/buffered_async_test.go
@@ -13,140 +13,130 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const maxProcessingDuration = time.Second
-const pollingInterval = 10 * time.Millisecond
+const (
+	maxProcessingDuration = time.Second
+	pollingInterval       = 10 * time.Millisecond
+	contextTimeout        = 30 * time.Second
+)
 
 func TestBufferedAsyncSend(t *testing.T) {
-	s, err := NewInternalLogger("buffs", LevelInfo{level.Debug, level.Debug})
-	require.NoError(t, err)
+	var s *InternalSender
 
-	t.Run("RespectsPriority", func(t *testing.T) {
-		bs, ctx, cancel := newBufferedAsyncSender(s, time.Minute, 1)
-		defer cancel()
+	for name, test := range map[string]func(*testing.T){
+		"RespectsPriority": func(t *testing.T) {
+			bs, ctx, cancel := newBufferedAsyncSender(s, time.Minute, 1)
+			defer cancel()
 
-		bs.Send(message.ConvertToComposer(level.Trace, "should not send"))
-		assert.False(t, checkMessageSent(ctx, bs, s))
-	})
-	t.Run("FlushesAtCapactiy", func(t *testing.T) {
-		bufferSize := 10
-		bs, ctx, cancel := newBufferedAsyncSender(s, time.Minute, bufferSize)
-		defer cancel()
+			bs.Send(message.ConvertToComposer(level.Trace, "should not send"))
+			assert.False(t, checkMessageSent(ctx, bs, s))
+		},
+		"FlushesAtCapacity": func(t *testing.T) {
+			bufferSize := 10
+			bs, ctx, cancel := newBufferedAsyncSender(s, time.Minute, bufferSize)
+			defer cancel()
 
-		for i := 0; i < bufferSize; i++ {
-			bs.Send(message.ConvertToComposer(level.Debug, fmt.Sprintf("message %d", i+1)))
-		}
-
-		require.True(t, checkMessageSent(ctx, bs, s))
-		msg := s.GetMessage()
-		msgs := strings.Split(msg.Message.String(), "\n")
-		assert.Len(t, msgs, 10)
-		for i, msg := range msgs {
-			require.Equal(t, fmt.Sprintf("message %d", i+1), msg)
-		}
-	})
-	t.Run("FlushesOnInterval", func(t *testing.T) {
-		interval := maxProcessingDuration / 2
-		bs, ctx, cancel := newBufferedAsyncSender(s, interval, 10)
-		defer cancel()
-
-		bs.Send(message.ConvertToComposer(level.Debug, "should flush"))
-		require.True(t, checkMessageSent(ctx, bs, s))
-		msg := s.GetMessage()
-		assert.Equal(t, "should flush", msg.Message.String())
-	})
-	t.Run("OverflowBuffer", func(t *testing.T) {
-		bs, ctx, cancel := newBufferedAsyncSender(s, time.Minute, 10)
-		defer cancel()
-		var capturedErr error
-		assert.NoError(t, bs.SetErrorHandler(func(err error, _ message.Composer) { capturedErr = err }))
-
-		for x := 0; x < defaultIncomingBufferFactor*10; x++ {
-			bs.Send(message.ConvertToComposer(level.Debug, "message"))
-		}
-
-		bs.Send(message.ConvertToComposer(level.Debug, "over the limit"))
-		require.True(t, checkMessageSent(ctx, bs, s))
-		msg := s.GetMessage()
-		msgString := msg.Message.String()
-		assert.NotContains(t, "over the limit", msgString)
-
-		require.Error(t, capturedErr)
-		assert.Equal(t, capturedErr.Error(), "the message has been dropped")
-	})
-}
-
-func TestBufferedAsyncFlush(t *testing.T) {
-	s, err := NewInternalLogger("buffs", LevelInfo{level.Debug, level.Debug})
-	require.NoError(t, err)
-
-	t.Run("ForceFlush", func(t *testing.T) {
-		bs, ctx, cancel := newBufferedAsyncSender(s, time.Minute, 10)
-		defer cancel()
-
-		bs.Send(message.ConvertToComposer(level.Debug, "message"))
-		require.NoError(t, bs.Flush(nil))
-		require.True(t, checkMessageSent(ctx, bs, s))
-		msg := s.GetMessage()
-		assert.Equal(t, "message", msg.Message.String())
-	})
-}
-
-func TestBufferedAsyncClose(t *testing.T) {
-	s, err := NewInternalLogger("buffs", LevelInfo{level.Debug, level.Debug})
-	require.NoError(t, err)
-
-	t.Run("NonEmptyBuffer", func(t *testing.T) {
-		bs, ctx, cancel := newBufferedAsyncSender(s, time.Minute, 10)
-		defer cancel()
-
-		for _, msg := range []message.Composer{
-			message.ConvertToComposer(level.Debug, "message1"),
-			message.ConvertToComposer(level.Debug, "message2"),
-			message.ConvertToComposer(level.Debug, "message3"),
-		} {
-			bs.Send(msg)
-		}
-
-		assert.NoError(t, bs.Close())
-		require.True(t, checkMessageSent(ctx, bs, s))
-		msgs := s.GetMessage()
-		assert.Equal(t, "message1\nmessage2\nmessage3", msgs.Message.String())
-	})
-	t.Run("CloseIsIdempotent", func(t *testing.T) {
-		bs, _, cancel := newBufferedAsyncSender(s, time.Minute, 10)
-		defer cancel()
-
-		assert.NoError(t, bs.Close())
-		assert.NoError(t, bs.Close())
-	})
-}
-
-func TestProcessMessages(t *testing.T) {
-	t.Run("ReturnsWhenClosed", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-
-		bs := &bufferedAsyncSender{
-			cancel: cancel,
-			opts:   BufferedAsyncSenderOptions{FlushInterval: time.Second},
-		}
-		done := make(chan bool)
-
-		go func() {
-			bs.processMessages(ctx)
-			done <- true
-		}()
-		assert.NoError(t, bs.Close())
-
-		assert.Eventually(t, func() bool {
-			select {
-			case <-done:
-				return true
-			default:
-				return false
+			for i := 0; i < bufferSize; i++ {
+				bs.Send(message.ConvertToComposer(level.Debug, fmt.Sprintf("message %d", i+1)))
 			}
-		}, maxProcessingDuration, pollingInterval)
-	})
+
+			require.True(t, checkMessageSent(ctx, bs, s))
+			msg := s.GetMessage()
+			msgs := strings.Split(msg.Message.String(), "\n")
+			assert.Len(t, msgs, 10)
+			for i, msg := range msgs {
+				require.Equal(t, fmt.Sprintf("message %d", i+1), msg)
+			}
+		},
+		"FlushesOnInterval": func(t *testing.T) {
+			interval := maxProcessingDuration / 2
+			bs, ctx, cancel := newBufferedAsyncSender(s, interval, 10)
+			defer cancel()
+
+			bs.Send(message.ConvertToComposer(level.Debug, "should flush"))
+			require.True(t, checkMessageSent(ctx, bs, s))
+			msg := s.GetMessage()
+			assert.Equal(t, "should flush", msg.Message.String())
+		},
+		"OverflowBuffer": func(t *testing.T) {
+			bs, ctx, cancel := newBufferedAsyncSender(s, time.Minute, 10)
+			defer cancel()
+			var capturedErr error
+			assert.NoError(t, bs.SetErrorHandler(func(err error, _ message.Composer) { capturedErr = err }))
+
+			for x := 0; x < defaultIncomingBufferFactor*10; x++ {
+				bs.Send(message.ConvertToComposer(level.Debug, "message"))
+			}
+
+			bs.Send(message.ConvertToComposer(level.Debug, "over the limit"))
+			require.True(t, checkMessageSent(ctx, bs, s))
+			msg := s.GetMessage()
+			msgString := msg.Message.String()
+			assert.NotContains(t, "over the limit", msgString)
+
+			require.Error(t, capturedErr)
+			assert.Equal(t, "the message was dropped because the buffer was full", capturedErr.Error())
+		},
+		"ReturnsWhenClosed": func(t *testing.T) {
+			bs, ctx, cancel := newBufferedAsyncSender(s, time.Minute, 10)
+			defer cancel()
+
+			done := make(chan bool)
+
+			go func() {
+				bs.processMessages(ctx)
+				done <- true
+			}()
+			assert.NoError(t, bs.Close())
+
+			assert.Eventually(t, func() bool {
+				select {
+				case <-done:
+					return true
+				default:
+					return false
+				}
+			}, maxProcessingDuration, pollingInterval)
+		},
+		"ForceFlush": func(t *testing.T) {
+			bs, ctx, cancel := newBufferedAsyncSender(s, time.Minute, 10)
+			defer cancel()
+
+			bs.Send(message.ConvertToComposer(level.Debug, "message"))
+			require.NoError(t, bs.Flush(nil))
+			require.True(t, checkMessageSent(ctx, bs, s))
+			msg := s.GetMessage()
+			assert.Equal(t, "message", msg.Message.String())
+		},
+		"NonEmptyBuffer": func(t *testing.T) {
+			bs, ctx, cancel := newBufferedAsyncSender(s, time.Minute, 10)
+			defer cancel()
+
+			for _, msg := range []message.Composer{
+				message.ConvertToComposer(level.Debug, "message1"),
+				message.ConvertToComposer(level.Debug, "message2"),
+				message.ConvertToComposer(level.Debug, "message3"),
+			} {
+				bs.Send(msg)
+			}
+
+			assert.NoError(t, bs.Close())
+			require.True(t, checkMessageSent(ctx, bs, s))
+			msgs := s.GetMessage()
+			assert.Equal(t, "message1\nmessage2\nmessage3", msgs.Message.String())
+		},
+		"CloseIsIdempotent": func(t *testing.T) {
+			bs, _, cancel := newBufferedAsyncSender(s, time.Minute, 10)
+			defer cancel()
+
+			assert.NoError(t, bs.Close())
+			assert.NoError(t, bs.Close())
+		},
+	} {
+		var err error
+		s, err = NewInternalLogger("buffs", LevelInfo{level.Debug, level.Debug})
+		require.NoError(t, err)
+		t.Run(name, test)
+	}
 }
 
 func checkMessageSent(ctx context.Context, bs *bufferedAsyncSender, s *InternalSender) bool {
@@ -178,7 +168,7 @@ FOR:
 }
 
 func newBufferedAsyncSender(sender Sender, interval time.Duration, size int) (*bufferedAsyncSender, context.Context, context.CancelFunc) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), contextTimeout)
 	bs := &bufferedAsyncSender{
 		Sender:     sender,
 		cancel:     cancel,

--- a/send/buffered_async_test.go
+++ b/send/buffered_async_test.go
@@ -30,7 +30,7 @@ func TestBufferedAsyncSend(t *testing.T) {
 			Sender:     s,
 			ctx:        ctx,
 			cancel:     cancel,
-			opts:       BufferedAsyncSenderOptions{FlushInterval: interval},
+			opts:       BufferedAsyncSenderOptions{BufferedSenderOptions: BufferedSenderOptions{FlushInterval: interval}},
 			buffer:     make([]message.Composer, 0, size),
 			needsFlush: make(chan bool, 1),
 			incoming:   make(chan message.Composer, defaultIncomingBufferFactor*size),

--- a/send/buffered_async_test.go
+++ b/send/buffered_async_test.go
@@ -60,7 +60,7 @@ func TestBufferedAsyncSend(t *testing.T) {
 		var capturedErr error
 		assert.NoError(t, bs.SetErrorHandler(func(err error, _ message.Composer) { capturedErr = err }))
 
-		for x := 0; x < incomingBufferFactor*10; x++ {
+		for x := 0; x < defaultIncomingBufferFactor*10; x++ {
 			bs.Send(message.ConvertToComposer(level.Debug, "message"))
 		}
 
@@ -185,7 +185,7 @@ func newBufferedAsyncSender(sender Sender, interval time.Duration, size int) (*b
 		opts:       BufferedAsyncSenderOptions{FlushInterval: interval},
 		buffer:     make([]message.Composer, 0, size),
 		needsFlush: make(chan bool, 1),
-		incoming:   make(chan message.Composer, incomingBufferFactor*size),
+		incoming:   make(chan message.Composer, defaultIncomingBufferFactor*size),
 	}
 	return bs, ctx, cancel
 }

--- a/send/buffered_async_test.go
+++ b/send/buffered_async_test.go
@@ -1,0 +1,191 @@
+package send
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mongodb/grip/level"
+	"github.com/mongodb/grip/message"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const maxProcessingDuration = time.Second
+const pollingInterval = 10 * time.Millisecond
+
+func TestBufferedAsyncSend(t *testing.T) {
+	s, err := NewInternalLogger("buffs", LevelInfo{level.Debug, level.Debug})
+	require.NoError(t, err)
+
+	t.Run("RespectsPriority", func(t *testing.T) {
+		bs, ctx, cancel := newBufferedAsyncSender(s, time.Minute, 1)
+		defer cancel()
+
+		bs.Send(message.ConvertToComposer(level.Trace, "should not send"))
+		assert.False(t, checkMessageSent(ctx, bs, s))
+	})
+	t.Run("FlushesAtCapactiy", func(t *testing.T) {
+		bufferSize := 10
+		bs, ctx, cancel := newBufferedAsyncSender(s, time.Minute, bufferSize)
+		defer cancel()
+
+		for i := 0; i < bufferSize; i++ {
+			bs.Send(message.ConvertToComposer(level.Debug, fmt.Sprintf("message %d", i+1)))
+		}
+
+		require.True(t, checkMessageSent(ctx, bs, s))
+		msg := s.GetMessage()
+		msgs := strings.Split(msg.Message.String(), "\n")
+		assert.Len(t, msgs, 10)
+		for i, msg := range msgs {
+			require.Equal(t, fmt.Sprintf("message %d", i+1), msg)
+		}
+	})
+	t.Run("FlushesOnInterval", func(t *testing.T) {
+		interval := maxProcessingDuration / 2
+		bs, ctx, cancel := newBufferedAsyncSender(s, interval, 10)
+		defer cancel()
+
+		bs.Send(message.ConvertToComposer(level.Debug, "should flush"))
+		require.True(t, checkMessageSent(ctx, bs, s))
+		msg := s.GetMessage()
+		assert.Equal(t, "should flush", msg.Message.String())
+	})
+	t.Run("OverflowBuffer", func(t *testing.T) {
+		bs, ctx, cancel := newBufferedAsyncSender(s, time.Minute, 10)
+		defer cancel()
+		var capturedErr error
+		assert.NoError(t, bs.SetErrorHandler(func(err error, _ message.Composer) { capturedErr = err }))
+
+		for x := 0; x < incomingBufferFactor*10; x++ {
+			bs.Send(message.ConvertToComposer(level.Debug, "message"))
+		}
+
+		bs.Send(message.ConvertToComposer(level.Debug, "over the limit"))
+		require.True(t, checkMessageSent(ctx, bs, s))
+		msg := s.GetMessage()
+		msgString := msg.Message.String()
+		assert.NotContains(t, "over the limit", msgString)
+
+		require.Error(t, capturedErr)
+		assert.Equal(t, capturedErr.Error(), "the message has been dropped")
+	})
+}
+
+func TestBufferedAsyncFlush(t *testing.T) {
+	s, err := NewInternalLogger("buffs", LevelInfo{level.Debug, level.Debug})
+	require.NoError(t, err)
+
+	t.Run("ForceFlush", func(t *testing.T) {
+		bs, ctx, cancel := newBufferedAsyncSender(s, time.Minute, 10)
+		defer cancel()
+
+		bs.Send(message.ConvertToComposer(level.Debug, "message"))
+		require.NoError(t, bs.Flush(nil))
+		require.True(t, checkMessageSent(ctx, bs, s))
+		msg := s.GetMessage()
+		assert.Equal(t, "message", msg.Message.String())
+	})
+}
+
+func TestBufferedAsyncClose(t *testing.T) {
+	s, err := NewInternalLogger("buffs", LevelInfo{level.Debug, level.Debug})
+	require.NoError(t, err)
+
+	t.Run("NonEmptyBuffer", func(t *testing.T) {
+		bs, ctx, cancel := newBufferedAsyncSender(s, time.Minute, 10)
+		defer cancel()
+
+		for _, msg := range []message.Composer{
+			message.ConvertToComposer(level.Debug, "message1"),
+			message.ConvertToComposer(level.Debug, "message2"),
+			message.ConvertToComposer(level.Debug, "message3"),
+		} {
+			bs.Send(msg)
+		}
+
+		assert.NoError(t, bs.Close())
+		require.True(t, checkMessageSent(ctx, bs, s))
+		msgs := s.GetMessage()
+		assert.Equal(t, "message1\nmessage2\nmessage3", msgs.Message.String())
+	})
+	t.Run("CloseIsIdempotent", func(t *testing.T) {
+		bs, _, cancel := newBufferedAsyncSender(s, time.Minute, 10)
+		defer cancel()
+
+		assert.NoError(t, bs.Close())
+		assert.NoError(t, bs.Close())
+	})
+}
+
+func TestProcessMessages(t *testing.T) {
+	t.Run("ReturnsWhenClosed", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		bs := &bufferedAsyncSender{
+			cancel: cancel,
+			opts:   BufferedAsyncSenderOptions{FlushInterval: time.Second},
+		}
+		done := make(chan bool)
+
+		go func() {
+			bs.processMessages(ctx)
+			done <- true
+		}()
+		assert.NoError(t, bs.Close())
+
+		assert.Eventually(t, func() bool {
+			select {
+			case <-done:
+				return true
+			default:
+				return false
+			}
+		}, maxProcessingDuration, pollingInterval)
+	})
+}
+
+func checkMessageSent(ctx context.Context, bs *bufferedAsyncSender, s *InternalSender) bool {
+	done := make(chan bool)
+	go func() {
+		bs.processMessages(ctx)
+		done <- true
+	}()
+
+	begin := time.Now()
+
+	ticker := time.NewTicker(pollingInterval)
+	defer ticker.Stop()
+
+FOR:
+	for {
+		select {
+		case <-done:
+			break FOR
+		case <-ticker.C:
+			if s.HasMessage() || time.Since(begin) > maxProcessingDuration {
+				bs.Close()
+				break FOR
+			}
+		}
+	}
+
+	return s.HasMessage()
+}
+
+func newBufferedAsyncSender(sender Sender, interval time.Duration, size int) (*bufferedAsyncSender, context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(context.Background())
+	bs := &bufferedAsyncSender{
+		Sender:     sender,
+		cancel:     cancel,
+		opts:       BufferedAsyncSenderOptions{FlushInterval: interval},
+		buffer:     make([]message.Composer, 0, size),
+		needsFlush: make(chan bool, 1),
+		incoming:   make(chan message.Composer, incomingBufferFactor*size),
+	}
+	return bs, ctx, cancel
+}

--- a/send/buffered_test.go
+++ b/send/buffered_test.go
@@ -13,30 +13,31 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const maxProcessingDuration = time.Second
+const pollingInterval = 10 * time.Millisecond
+
 func TestBufferedSend(t *testing.T) {
 	s, err := NewInternalLogger("buffs", LevelInfo{level.Debug, level.Debug})
 	require.NoError(t, err)
 
 	t.Run("RespectsPriority", func(t *testing.T) {
-		bs := newBufferedSender(s, time.Minute, 10)
-		defer bs.cancel()
+		bs, cancel := newBufferedSender(s, time.Minute, 1)
+		defer cancel()
 
-		bs.Send(message.ConvertToComposer(level.Trace, fmt.Sprintf("should not send")))
-		assert.Empty(t, bs.buffer)
-		_, ok := s.GetMessageSafe()
-		assert.False(t, ok)
+		bs.Send(message.ConvertToComposer(level.Trace, "should not send"))
+		assert.False(t, checkMessageSent(bs, s))
 	})
 	t.Run("FlushesAtCapactiy", func(t *testing.T) {
-		bs := newBufferedSender(s, time.Minute, 10)
-		defer bs.cancel()
+		bufferSize := 10
+		bs, cancel := newBufferedSender(s, time.Minute, bufferSize)
+		defer cancel()
 
-		for i := 0; i < 12; i++ {
-			require.Len(t, bs.buffer, i%10)
+		for i := 0; i < bufferSize; i++ {
 			bs.Send(message.ConvertToComposer(level.Debug, fmt.Sprintf("message %d", i+1)))
 		}
-		assert.Len(t, bs.buffer, 2)
-		msg, ok := s.GetMessageSafe()
-		require.True(t, ok)
+
+		require.True(t, checkMessageSent(bs, s))
+		msg := s.GetMessage()
 		msgs := strings.Split(msg.Message.String(), "\n")
 		assert.Len(t, msgs, 10)
 		for i, msg := range msgs {
@@ -44,27 +45,43 @@ func TestBufferedSend(t *testing.T) {
 		}
 	})
 	t.Run("FlushesOnInterval", func(t *testing.T) {
-		bs := newBufferedSender(s, 5*time.Second, 10)
-		defer bs.cancel()
+		interval := maxProcessingDuration / 2
+		bs, cancel := newBufferedSender(s, interval, 10)
+		defer cancel()
 
 		bs.Send(message.ConvertToComposer(level.Debug, "should flush"))
-		time.Sleep(6 * time.Second)
-		bs.mu.Lock()
-		assert.True(t, time.Since(bs.lastFlush) <= 2*time.Second)
-		bs.mu.Unlock()
-		msg, ok := s.GetMessageSafe()
-		require.True(t, ok)
+		require.True(t, checkMessageSent(bs, s))
+		msg := s.GetMessage()
 		assert.Equal(t, "should flush", msg.Message.String())
 	})
 	t.Run("ClosedSender", func(t *testing.T) {
-		bs := newBufferedSender(s, time.Minute, 10)
-		bs.closed = true
-		defer bs.cancel()
+		bs, cancel := newBufferedSender(s, time.Minute, 1)
+		defer cancel()
+
+		assert.NoError(t, bs.Close())
 
 		bs.Send(message.ConvertToComposer(level.Debug, "should not send"))
+		assert.False(t, checkMessageSent(bs, s))
 		assert.Empty(t, bs.buffer)
-		_, ok := s.GetMessageSafe()
-		assert.False(t, ok)
+	})
+	t.Run("OverflowBuffer", func(t *testing.T) {
+		bs, cancel := newBufferedSender(s, time.Minute, 10)
+		defer cancel()
+		var capturedErr error
+		assert.NoError(t, bs.SetErrorHandler(func(err error, _ message.Composer) { capturedErr = err }))
+
+		for x := 0; x < incomingBufferFactor*10; x++ {
+			bs.Send(message.ConvertToComposer(level.Debug, "message"))
+		}
+
+		bs.Send(message.ConvertToComposer(level.Debug, "over the limit"))
+		require.True(t, checkMessageSent(bs, s))
+		msg := s.GetMessage()
+		msgString := msg.Message.String()
+		assert.NotContains(t, "over the limit", msgString)
+
+		require.Error(t, capturedErr)
+		assert.Equal(t, capturedErr.Error(), "the message has been dropped")
 	})
 }
 
@@ -73,30 +90,25 @@ func TestFlush(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("ForceFlush", func(t *testing.T) {
-		bs := newBufferedSender(s, time.Minute, 10)
-		defer bs.cancel()
+		bs, cancel := newBufferedSender(s, time.Minute, 10)
+		defer cancel()
 
 		bs.Send(message.ConvertToComposer(level.Debug, "message"))
-		assert.Len(t, bs.buffer, 1)
-		require.NoError(t, bs.Flush(context.TODO()))
-		bs.mu.Lock()
-		assert.True(t, time.Since(bs.lastFlush) <= time.Second)
-		bs.mu.Unlock()
-		assert.Empty(t, bs.buffer)
-		msg, ok := s.GetMessageSafe()
-		require.True(t, ok)
+		require.NoError(t, bs.Flush(nil))
+		require.True(t, checkMessageSent(bs, s))
+		msg := s.GetMessage()
 		assert.Equal(t, "message", msg.Message.String())
 	})
 	t.Run("ClosedSender", func(t *testing.T) {
-		bs := newBufferedSender(s, time.Minute, 10)
-		bs.buffer = append(bs.buffer, message.ConvertToComposer(level.Debug, "message"))
-		bs.cancel()
-		bs.closed = true
+		bs, cancel := newBufferedSender(s, time.Minute, 10)
+		defer cancel()
 
-		assert.NoError(t, bs.Flush(context.TODO()))
+		assert.NoError(t, bs.Close())
+		bs.buffer = append(bs.buffer, message.ConvertToComposer(level.Debug, "message"))
+
+		assert.NoError(t, bs.Flush(nil))
 		assert.Len(t, bs.buffer, 1)
-		_, ok := s.GetMessageSafe()
-		assert.False(t, ok)
+		assert.False(t, checkMessageSent(bs, s))
 	})
 }
 
@@ -105,61 +117,107 @@ func TestBufferedClose(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("EmptyBuffer", func(t *testing.T) {
-		bs := newBufferedSender(s, time.Minute, 10)
+		bs, cancel := newBufferedSender(s, time.Minute, 10)
+		defer cancel()
 
-		assert.Nil(t, bs.Close())
-		assert.True(t, bs.closed)
-		_, ok := s.GetMessageSafe()
-		assert.False(t, ok)
+		assert.NoError(t, bs.Close())
+		assert.Error(t, bs.ctx.Err())
+		assert.False(t, checkMessageSent(bs, s))
 	})
 	t.Run("NonEmptyBuffer", func(t *testing.T) {
-		bs := newBufferedSender(s, time.Minute, 10)
-		bs.buffer = append(
-			bs.buffer,
+		bs, cancel := newBufferedSender(s, time.Minute, 10)
+		defer cancel()
+
+		for _, msg := range []message.Composer{
 			message.ConvertToComposer(level.Debug, "message1"),
 			message.ConvertToComposer(level.Debug, "message2"),
 			message.ConvertToComposer(level.Debug, "message3"),
-		)
+		} {
+			bs.Send(msg)
+		}
 
-		assert.Nil(t, bs.Close())
-		assert.True(t, bs.closed)
-		assert.Empty(t, bs.buffer)
-		msgs, ok := s.GetMessageSafe()
-		require.True(t, ok)
+		assert.NoError(t, bs.Close())
+		assert.Error(t, bs.ctx.Err())
+		require.True(t, checkMessageSent(bs, s))
+		msgs := s.GetMessage()
 		assert.Equal(t, "message1\nmessage2\nmessage3", msgs.Message.String())
 	})
-	t.Run("NoopWhenClosed", func(t *testing.T) {
-		bs := newBufferedSender(s, time.Minute, 10)
+	t.Run("CloseIsIdempotent", func(t *testing.T) {
+		bs, cancel := newBufferedSender(s, time.Minute, 10)
+		defer cancel()
 
 		assert.NoError(t, bs.Close())
-		assert.True(t, bs.closed)
+		assert.Error(t, bs.ctx.Err())
 		assert.NoError(t, bs.Close())
 	})
 }
 
-func TestIntervalFlush(t *testing.T) {
-	s, err := NewInternalLogger("buffs", LevelInfo{level.Debug, level.Debug})
-	require.NoError(t, err)
-
+func TestConsumer(t *testing.T) {
 	t.Run("ReturnsWhenClosed", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
 		bs := &bufferedSender{
-			Sender: s,
-			buffer: []message.Composer{},
+			ctx:    ctx,
 			cancel: cancel,
+			opts:   BufferedSenderOptions{FlushInterval: time.Second},
 		}
-		canceled := make(chan bool)
+		done := make(chan bool)
 
 		go func() {
-			bs.intervalFlush(ctx, time.Minute)
-			canceled <- true
+			bs.consumer()
+			done <- true
 		}()
 		assert.NoError(t, bs.Close())
-		assert.True(t, <-canceled)
+
+		assert.Eventually(t, func() bool {
+			select {
+			case <-done:
+				return true
+			default:
+				return false
+			}
+		}, maxProcessingDuration, pollingInterval)
 	})
 }
 
-func newBufferedSender(sender Sender, interval time.Duration, size int) *bufferedSender {
-	bs := NewBufferedSender(sender, interval, size)
-	return bs.(*bufferedSender)
+func checkMessageSent(bs *bufferedSender, s *InternalSender) bool {
+	done := make(chan bool)
+	go func() {
+		bs.consumer()
+		done <- true
+	}()
+
+	begin := time.Now()
+
+	ticker := time.NewTicker(pollingInterval)
+	defer ticker.Stop()
+
+FOR:
+	for {
+		select {
+		case <-done:
+			break FOR
+		case <-ticker.C:
+			if s.HasMessage() || time.Since(begin) > maxProcessingDuration {
+				break FOR
+			}
+		}
+	}
+
+	return s.HasMessage()
+}
+
+func newBufferedSender(sender Sender, interval time.Duration, size int) (*bufferedSender, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(context.Background())
+	bs := &bufferedSender{
+		Sender:     sender,
+		ctx:        ctx,
+		cancel:     cancel,
+		opts:       BufferedSenderOptions{FlushInterval: interval},
+		buffer:     make([]message.Composer, 0, size),
+		needsFlush: make(chan bool, 1),
+		incoming:   make(chan message.Composer, incomingBufferFactor*size),
+	}
+	return bs, cancel
 }

--- a/send/buffered_test.go
+++ b/send/buffered_test.go
@@ -13,31 +13,30 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const maxProcessingDuration = time.Second
-const pollingInterval = 10 * time.Millisecond
-
 func TestBufferedSend(t *testing.T) {
 	s, err := NewInternalLogger("buffs", LevelInfo{level.Debug, level.Debug})
 	require.NoError(t, err)
 
 	t.Run("RespectsPriority", func(t *testing.T) {
-		bs, cancel := newBufferedSender(s, time.Minute, 1)
-		defer cancel()
+		bs := newBufferedSender(s, time.Minute, 10)
+		defer bs.cancel()
 
-		bs.Send(message.ConvertToComposer(level.Trace, "should not send"))
-		assert.False(t, checkMessageSent(bs, s))
+		bs.Send(message.ConvertToComposer(level.Trace, fmt.Sprintf("should not send")))
+		assert.Empty(t, bs.buffer)
+		_, ok := s.GetMessageSafe()
+		assert.False(t, ok)
 	})
 	t.Run("FlushesAtCapactiy", func(t *testing.T) {
-		bufferSize := 10
-		bs, cancel := newBufferedSender(s, time.Minute, bufferSize)
-		defer cancel()
+		bs := newBufferedSender(s, time.Minute, 10)
+		defer bs.cancel()
 
-		for i := 0; i < bufferSize; i++ {
+		for i := 0; i < 12; i++ {
+			require.Len(t, bs.buffer, i%10)
 			bs.Send(message.ConvertToComposer(level.Debug, fmt.Sprintf("message %d", i+1)))
 		}
-
-		require.True(t, checkMessageSent(bs, s))
-		msg := s.GetMessage()
+		assert.Len(t, bs.buffer, 2)
+		msg, ok := s.GetMessageSafe()
+		require.True(t, ok)
 		msgs := strings.Split(msg.Message.String(), "\n")
 		assert.Len(t, msgs, 10)
 		for i, msg := range msgs {
@@ -45,43 +44,27 @@ func TestBufferedSend(t *testing.T) {
 		}
 	})
 	t.Run("FlushesOnInterval", func(t *testing.T) {
-		interval := maxProcessingDuration / 2
-		bs, cancel := newBufferedSender(s, interval, 10)
-		defer cancel()
+		bs := newBufferedSender(s, 5*time.Second, 10)
+		defer bs.cancel()
 
 		bs.Send(message.ConvertToComposer(level.Debug, "should flush"))
-		require.True(t, checkMessageSent(bs, s))
-		msg := s.GetMessage()
+		time.Sleep(6 * time.Second)
+		bs.mu.Lock()
+		assert.True(t, time.Since(bs.lastFlush) <= 2*time.Second)
+		bs.mu.Unlock()
+		msg, ok := s.GetMessageSafe()
+		require.True(t, ok)
 		assert.Equal(t, "should flush", msg.Message.String())
 	})
 	t.Run("ClosedSender", func(t *testing.T) {
-		bs, cancel := newBufferedSender(s, time.Minute, 1)
-		defer cancel()
-
-		assert.NoError(t, bs.Close())
+		bs := newBufferedSender(s, time.Minute, 10)
+		bs.closed = true
+		defer bs.cancel()
 
 		bs.Send(message.ConvertToComposer(level.Debug, "should not send"))
-		assert.False(t, checkMessageSent(bs, s))
 		assert.Empty(t, bs.buffer)
-	})
-	t.Run("OverflowBuffer", func(t *testing.T) {
-		bs, cancel := newBufferedSender(s, time.Minute, 10)
-		defer cancel()
-		var capturedErr error
-		assert.NoError(t, bs.SetErrorHandler(func(err error, _ message.Composer) { capturedErr = err }))
-
-		for x := 0; x < incomingBufferFactor*10; x++ {
-			bs.Send(message.ConvertToComposer(level.Debug, "message"))
-		}
-
-		bs.Send(message.ConvertToComposer(level.Debug, "over the limit"))
-		require.True(t, checkMessageSent(bs, s))
-		msg := s.GetMessage()
-		msgString := msg.Message.String()
-		assert.NotContains(t, "over the limit", msgString)
-
-		require.Error(t, capturedErr)
-		assert.Equal(t, capturedErr.Error(), "the message has been dropped")
+		_, ok := s.GetMessageSafe()
+		assert.False(t, ok)
 	})
 }
 
@@ -90,25 +73,30 @@ func TestFlush(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("ForceFlush", func(t *testing.T) {
-		bs, cancel := newBufferedSender(s, time.Minute, 10)
-		defer cancel()
+		bs := newBufferedSender(s, time.Minute, 10)
+		defer bs.cancel()
 
 		bs.Send(message.ConvertToComposer(level.Debug, "message"))
-		require.NoError(t, bs.Flush(nil))
-		require.True(t, checkMessageSent(bs, s))
-		msg := s.GetMessage()
+		assert.Len(t, bs.buffer, 1)
+		require.NoError(t, bs.Flush(context.TODO()))
+		bs.mu.Lock()
+		assert.True(t, time.Since(bs.lastFlush) <= time.Second)
+		bs.mu.Unlock()
+		assert.Empty(t, bs.buffer)
+		msg, ok := s.GetMessageSafe()
+		require.True(t, ok)
 		assert.Equal(t, "message", msg.Message.String())
 	})
 	t.Run("ClosedSender", func(t *testing.T) {
-		bs, cancel := newBufferedSender(s, time.Minute, 10)
-		defer cancel()
-
-		assert.NoError(t, bs.Close())
+		bs := newBufferedSender(s, time.Minute, 10)
 		bs.buffer = append(bs.buffer, message.ConvertToComposer(level.Debug, "message"))
+		bs.cancel()
+		bs.closed = true
 
-		assert.NoError(t, bs.Flush(nil))
+		assert.NoError(t, bs.Flush(context.TODO()))
 		assert.Len(t, bs.buffer, 1)
-		assert.False(t, checkMessageSent(bs, s))
+		_, ok := s.GetMessageSafe()
+		assert.False(t, ok)
 	})
 }
 
@@ -117,108 +105,61 @@ func TestBufferedClose(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("EmptyBuffer", func(t *testing.T) {
-		bs, cancel := newBufferedSender(s, time.Minute, 10)
-		defer cancel()
+		bs := newBufferedSender(s, time.Minute, 10)
 
-		assert.NoError(t, bs.Close())
-		assert.Error(t, bs.ctx.Err())
-		assert.False(t, checkMessageSent(bs, s))
+		assert.Nil(t, bs.Close())
+		assert.True(t, bs.closed)
+		_, ok := s.GetMessageSafe()
+		assert.False(t, ok)
 	})
 	t.Run("NonEmptyBuffer", func(t *testing.T) {
-		bs, cancel := newBufferedSender(s, time.Minute, 10)
-		defer cancel()
-
-		for _, msg := range []message.Composer{
+		bs := newBufferedSender(s, time.Minute, 10)
+		bs.buffer = append(
+			bs.buffer,
 			message.ConvertToComposer(level.Debug, "message1"),
 			message.ConvertToComposer(level.Debug, "message2"),
 			message.ConvertToComposer(level.Debug, "message3"),
-		} {
-			bs.Send(msg)
-		}
+		)
 
-		assert.NoError(t, bs.Close())
-		assert.Error(t, bs.ctx.Err())
-		require.True(t, checkMessageSent(bs, s))
-		msgs := s.GetMessage()
+		assert.Nil(t, bs.Close())
+		assert.True(t, bs.closed)
+		assert.Empty(t, bs.buffer)
+		msgs, ok := s.GetMessageSafe()
+		require.True(t, ok)
 		assert.Equal(t, "message1\nmessage2\nmessage3", msgs.Message.String())
 	})
-	t.Run("CloseIsIdempotent", func(t *testing.T) {
-		bs, cancel := newBufferedSender(s, time.Minute, 10)
-		defer cancel()
+	t.Run("NoopWhenClosed", func(t *testing.T) {
+		bs := newBufferedSender(s, time.Minute, 10)
 
 		assert.NoError(t, bs.Close())
-		assert.Error(t, bs.ctx.Err())
+		assert.True(t, bs.closed)
 		assert.NoError(t, bs.Close())
 	})
 }
 
-func TestConsumer(t *testing.T) {
+func TestIntervalFlush(t *testing.T) {
+	s, err := NewInternalLogger("buffs", LevelInfo{level.Debug, level.Debug})
+	require.NoError(t, err)
+
 	t.Run("ReturnsWhenClosed", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-
 		bs := &bufferedSender{
-			ctx:    ctx,
+			Sender: s,
+			buffer: []message.Composer{},
 			cancel: cancel,
-			opts:   BufferedSenderOptions{FlushInterval: time.Second},
 		}
-		done := make(chan bool)
+		canceled := make(chan bool)
 
 		go func() {
-			bs.processMessages()
-			done <- true
+			bs.intervalFlush(ctx, time.Minute)
+			canceled <- true
 		}()
 		assert.NoError(t, bs.Close())
-
-		assert.Eventually(t, func() bool {
-			select {
-			case <-done:
-				return true
-			default:
-				return false
-			}
-		}, maxProcessingDuration, pollingInterval)
+		assert.True(t, <-canceled)
 	})
 }
 
-func checkMessageSent(bs *bufferedSender, s *InternalSender) bool {
-	done := make(chan bool)
-	go func() {
-		bs.processMessages()
-		done <- true
-	}()
-
-	begin := time.Now()
-
-	ticker := time.NewTicker(pollingInterval)
-	defer ticker.Stop()
-
-FOR:
-	for {
-		select {
-		case <-done:
-			break FOR
-		case <-ticker.C:
-			if s.HasMessage() || time.Since(begin) > maxProcessingDuration {
-				bs.Close()
-				break FOR
-			}
-		}
-	}
-
-	return s.HasMessage()
-}
-
-func newBufferedSender(sender Sender, interval time.Duration, size int) (*bufferedSender, context.CancelFunc) {
-	ctx, cancel := context.WithCancel(context.Background())
-	bs := &bufferedSender{
-		Sender:     sender,
-		ctx:        ctx,
-		cancel:     cancel,
-		opts:       BufferedSenderOptions{FlushInterval: interval},
-		buffer:     make([]message.Composer, 0, size),
-		needsFlush: make(chan bool, 1),
-		incoming:   make(chan message.Composer, incomingBufferFactor*size),
-	}
-	return bs, cancel
+func newBufferedSender(sender Sender, interval time.Duration, size int) *bufferedSender {
+	bs := NewBufferedSender(sender, interval, size)
+	return bs.(*bufferedSender)
 }

--- a/send/buffered_test.go
+++ b/send/buffered_test.go
@@ -165,7 +165,7 @@ func TestConsumer(t *testing.T) {
 		done := make(chan bool)
 
 		go func() {
-			bs.consumer()
+			bs.processMessages()
 			done <- true
 		}()
 		assert.NoError(t, bs.Close())
@@ -184,7 +184,7 @@ func TestConsumer(t *testing.T) {
 func checkMessageSent(bs *bufferedSender, s *InternalSender) bool {
 	done := make(chan bool)
 	go func() {
-		bs.consumer()
+		bs.processMessages()
 		done <- true
 	}()
 
@@ -200,6 +200,7 @@ FOR:
 			break FOR
 		case <-ticker.C:
 			if s.HasMessage() || time.Since(begin) > maxProcessingDuration {
+				bs.Close()
 				break FOR
 			}
 		}

--- a/send/send_test.go
+++ b/send/send_test.go
@@ -200,12 +200,13 @@ func (s *SenderSuite) SetupTest() {
 }
 
 func (s *SenderSuite) TearDownTest() {
+	_ = s.senders["buffered-async"].Close()
+
 	if runtime.GOOS == "windows" {
 		_ = s.senders["native-file"].Close()
 		_ = s.senders["callsite-file"].Close()
 		_ = s.senders["json"].Close()
 		_ = s.senders["plain.file"].Close()
-		_ = s.senders["buffered-async"].Close()
 	}
 	s.Require().NoError(os.RemoveAll(s.tempDir))
 }

--- a/send/send_test.go
+++ b/send/send_test.go
@@ -139,10 +139,15 @@ func (s *SenderSuite) SetupTest() {
 
 	bufferedInternal, err := NewNativeLogger("buffered", l)
 	s.Require().NoError(err)
-	s.senders["buffered"], err = NewBufferedSender(
+	s.senders["buffered"] = NewBufferedSender(bufferedInternal, minInterval, 1)
+	s.Require().NoError(err)
+
+	bufferedAsyncInternal, err := NewNativeLogger("buffered-async", l)
+	s.Require().NoError(err)
+	s.senders["buffered-async"], err = NewBufferedAsyncSender(
 		context.Background(),
-		bufferedInternal,
-		BufferedSenderOptions{FlushInterval: minInterval, BufferSize: 1},
+		bufferedAsyncInternal,
+		BufferedAsyncSenderOptions{FlushInterval: minInterval, BufferSize: 1},
 	)
 	s.Require().NoError(err)
 

--- a/send/send_test.go
+++ b/send/send_test.go
@@ -205,6 +205,7 @@ func (s *SenderSuite) TearDownTest() {
 		_ = s.senders["callsite-file"].Close()
 		_ = s.senders["json"].Close()
 		_ = s.senders["plain.file"].Close()
+		_ = s.senders["buffered-async"].Close()
 	}
 	s.Require().NoError(os.RemoveAll(s.tempDir))
 }

--- a/send/send_test.go
+++ b/send/send_test.go
@@ -139,11 +139,12 @@ func (s *SenderSuite) SetupTest() {
 
 	bufferedInternal, err := NewNativeLogger("buffered", l)
 	s.Require().NoError(err)
-	s.senders["buffered"] = NewBufferedSender(
+	s.senders["buffered"], err = NewBufferedSender(
 		context.Background(),
 		bufferedInternal,
 		BufferedSenderOptions{FlushInterval: minInterval, BufferSize: 1},
 	)
+	s.Require().NoError(err)
 
 	s.senders["github"], err = NewGithubIssuesLogger("gh", &GithubOptions{})
 	s.Require().NoError(err)

--- a/send/send_test.go
+++ b/send/send_test.go
@@ -139,7 +139,11 @@ func (s *SenderSuite) SetupTest() {
 
 	bufferedInternal, err := NewNativeLogger("buffered", l)
 	s.Require().NoError(err)
-	s.senders["buffered"] = NewBufferedSender(bufferedInternal, minInterval, 1)
+	s.senders["buffered"] = NewBufferedSender(
+		context.Background(),
+		bufferedInternal,
+		BufferedSenderOptions{FlushInterval: minInterval, BufferSize: 1},
+	)
 
 	s.senders["github"], err = NewGithubIssuesLogger("gh", &GithubOptions{})
 	s.Require().NoError(err)

--- a/send/send_test.go
+++ b/send/send_test.go
@@ -139,15 +139,18 @@ func (s *SenderSuite) SetupTest() {
 
 	bufferedInternal, err := NewNativeLogger("buffered", l)
 	s.Require().NoError(err)
-	s.senders["buffered"] = NewBufferedSender(bufferedInternal, minInterval, 1)
+	s.senders["buffered"], err = NewBufferedSender(context.Background(), bufferedInternal, BufferedSenderOptions{FlushInterval: minFlushInterval, BufferSize: 1})
 	s.Require().NoError(err)
 
 	bufferedAsyncInternal, err := NewNativeLogger("buffered-async", l)
 	s.Require().NoError(err)
+	opts := BufferedAsyncSenderOptions{}
+	opts.FlushInterval = minFlushInterval
+	opts.BufferSize = 1
 	s.senders["buffered-async"], err = NewBufferedAsyncSender(
 		context.Background(),
 		bufferedAsyncInternal,
-		BufferedAsyncSenderOptions{FlushInterval: minInterval, BufferSize: 1},
+		opts,
 	)
 	s.Require().NoError(err)
 


### PR DESCRIPTION
https://jira.mongodb.org/browse/EVG-16236

Currently if messages come in faster than the underlying sender can process them sending goroutines are blocked waiting on the buffered sender's lock. I suspected this is what caused the recent outages and goroutine reports from the latest outage confirmed that there were large numbers of goroutines waiting on this lock.

This PR eliminates the lock in favor of "share memory by communicating." The primary benefit here is that when the underlying sender can't keep up we won't block callers trying to log messages. It also has the added benefit that now the API server goroutines won't all be contending on the same logger lock.

I considered adding an option to the logger to preserve the "block on full" behavior when we want it (so messages don't get dropped). If it would be valuable somewhere I can add it. 