### PR TITLE
EVG-16501: clean up error message style

### DIFF
--- a/message/slack.go
+++ b/message/slack.go
@@ -162,7 +162,7 @@ func (c *slackMessage) Annotate(key string, data interface{}) error {
 		return c.Base.Annotate(key, data)
 	}
 	if annotate == nil {
-		return errors.New("Annotate data must not be nil")
+		return errors.New("annotate data must not be nil")
 	}
 	if len(c.raw.Attachments) == slackMaxAttachments {
 		return fmt.Errorf("adding another Slack attachment would exceed maximum number of attachments, %d", slackMaxAttachments)

--- a/send/async_group.go
+++ b/send/async_group.go
@@ -62,8 +62,7 @@ func NewAsyncGroupSender(ctx context.Context, bufferSize int, senders ...Sender)
 
 		for idx, pipe := range s.pipes {
 			if len(pipe) > 0 {
-				errs = append(errs, fmt.Sprintf("buffer for sender #%d has %d items remaining",
-					idx, len(pipe)))
+				errs = append(errs, fmt.Sprintf("buffer for sender #%d has %d items remaining", idx, len(pipe)))
 
 			}
 			close(pipe)

--- a/send/benchmark/harness_case.go
+++ b/send/benchmark/harness_case.go
@@ -52,7 +52,7 @@ func (c *caseDefinition) StopTimer() {
 }
 
 func (c *caseDefinition) roundedRuntime() time.Duration {
-	return roundDurationMS(c.runtime)
+	return c.runtime.Round(time.Millisecond)
 }
 
 func (c *caseDefinition) Run(ctx context.Context) *benchResult {

--- a/send/benchmark/harness_results.go
+++ b/send/benchmark/harness_results.go
@@ -89,7 +89,7 @@ func (r *benchResult) totalDuration() time.Duration {
 
 func (r *benchResult) adjustResults(data float64) float64 { return bytesToMB(r.dataSize) / data }
 func (r *benchResult) getThroughput(data float64) float64 { return float64(r.operations) / data }
-func (r *benchResult) roundedRuntime() time.Duration      { return roundDurationMS(r.duration) }
+func (r *benchResult) roundedRuntime() time.Duration      { return r.duration.Round(time.Millisecond) }
 
 func (r *benchResult) String() string {
 	return fmt.Sprintf("name=%s, trials=%d, secs=%s", r.name, r.trials, r.duration)
@@ -124,10 +124,6 @@ type result struct {
 	duration   time.Duration
 	iterations int
 	err        error
-}
-
-func roundDurationMS(d time.Duration) time.Duration {
-	return d / 1e6 * time.Millisecond
 }
 
 func bytesToMB(numBytes int) float64 {

--- a/send/benchmark/harness_test.go
+++ b/send/benchmark/harness_test.go
@@ -32,7 +32,7 @@ func BenchmarkAllSenders(b *testing.B) {
 	if outputFileName == "" {
 		fmt.Println(string(evgOutput))
 	} else if err := ioutil.WriteFile(outputFileName, evgOutput, 0644); err != nil {
-		fmt.Fprintf(os.Stderr, "problem writing file '%s': %s", outputFileName, err.Error())
+		fmt.Fprintf(os.Stderr, "writing output file '%s': %s", outputFileName, err.Error())
 		return
 	}
 

--- a/send/buffered.go
+++ b/send/buffered.go
@@ -29,10 +29,10 @@ type BufferedSenderOptions struct {
 
 func (opts *BufferedSenderOptions) validate() error {
 	if opts.FlushInterval < 0 {
-		return errors.New("FlushInterval can not be negative")
+		return errors.New("FlushInterval cannot be negative")
 	}
 	if opts.BufferSize < 0 {
-		return errors.New("BufferSize can not be negative")
+		return errors.New("BufferSize cannot be negative")
 	}
 
 	if opts.FlushInterval == 0 {

--- a/send/buffered_async.go
+++ b/send/buffered_async.go
@@ -77,7 +77,7 @@ func (opts *BufferedAsyncSenderOptions) validate() error {
 	}
 
 	if opts.IncomingBufferFactor < 0 {
-		return errors.New("IncomingBufferFactor can not be negative")
+		return errors.New("IncomingBufferFactor cannot be negative")
 	}
 
 	if opts.IncomingBufferFactor == 0 {

--- a/send/generic.go
+++ b/send/generic.go
@@ -40,7 +40,7 @@ func (gl *genericLogger) Send(m message.Composer) {
 
 	generic := m.Raw().(message.Generic)
 	if err := generic.Send(); err != nil {
-		gl.ErrorHandler()(errors.Wrap(err, "problem processing generic message"), m)
+		gl.ErrorHandler()(errors.Wrap(err, "sending generic message"), m)
 	}
 }
 

--- a/send/github_status.go
+++ b/send/github_status.go
@@ -57,7 +57,7 @@ func (s *githubStatusMessageLogger) Send(m message.Composer) {
 			owner = s.ref
 		}
 		if status == nil {
-			s.ErrorHandler()(errors.New("composer cannot be converted to github status"), m)
+			s.ErrorHandler()(errors.New("composer cannot be converted to GitHub status"), m)
 			return
 		}
 

--- a/send/jira_comment.go
+++ b/send/jira_comment.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/mongodb/grip/level"
 	"github.com/mongodb/grip/message"
+	"github.com/pkg/errors"
 )
 
 type jiraCommentJournal struct {
@@ -50,7 +51,7 @@ func NewJiraCommentLogger(ctx context.Context, id string, opts *JiraOptions, l L
 		consumerKey:        opts.Oauth1Opts.ConsumerKey,
 	}
 	if err := j.opts.client.Authenticate(ctx, authOpts); err != nil {
-		return nil, fmt.Errorf("jira authentication error: %v", err)
+		return nil, errors.Wrap(err, "authenticating")
 	}
 
 	if err := j.SetLevel(l); err != nil {

--- a/send/native.go
+++ b/send/native.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/mongodb/grip/level"
 	"github.com/mongodb/grip/message"
+	"github.com/pkg/errors"
 )
 
 type nativeLogger struct {
@@ -41,7 +42,7 @@ func MakeFileLogger(filePath string) (Sender, error) {
 
 	f, err := os.OpenFile(filePath, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
 	if err != nil {
-		return nil, fmt.Errorf("error opening logging file, %s", err.Error())
+		return nil, errors.Wrapf(err, "opening output file '%s'", filePath)
 	}
 
 	s.level = LevelInfo{level.Trace, level.Trace}

--- a/send/plain.go
+++ b/send/plain.go
@@ -1,11 +1,11 @@
 package send
 
 import (
-	"fmt"
 	"log"
 	"os"
 
 	"github.com/mongodb/grip/level"
+	"github.com/pkg/errors"
 )
 
 // NewPlainLogger returns a configured sender that has no prefix and
@@ -63,7 +63,7 @@ func MakePlainFileLogger(filePath string) (Sender, error) {
 
 	f, err := os.OpenFile(filePath, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
 	if err != nil {
-		return nil, fmt.Errorf("error opening logging file, %s", err.Error())
+		return nil, errors.Wrapf(err, "opening output file '%s'", filePath)
 	}
 
 	s.level = LevelInfo{level.Trace, level.Trace}

--- a/send/slack.go
+++ b/send/slack.go
@@ -2,12 +2,13 @@ package send
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log"
 	"os"
 	"strings"
 	"sync"
+
+	"github.com/pkg/errors"
 
 	"github.com/bluele/slack"
 	"github.com/mongodb/grip/level"
@@ -42,7 +43,7 @@ func NewSlackLogger(opts *SlackOptions, token string, l LevelInfo) (Sender, erro
 	}
 
 	if _, err := s.opts.client.AuthTest(); err != nil {
-		return nil, fmt.Errorf("slack authentication error: %v", err)
+		return nil, errors.Wrap(err, "testing authentication")
 	}
 
 	fallback := log.New(os.Stdout, "", log.LstdFlags)

--- a/send/splunk.go
+++ b/send/splunk.go
@@ -56,10 +56,10 @@ func (info SplunkConnectionInfo) Populated() bool {
 
 func (info SplunkConnectionInfo) validateFromEnv() error {
 	if info.ServerURL == "" {
-		return errors.Errorf("environment variable %s not defined, cannot create splunk client", splunkServerURL)
+		return errors.Errorf("environment variable %s not defined", splunkServerURL)
 	}
 	if info.Token == "" {
-		return errors.Errorf("environment variable %s not defined, cannot create splunk client", splunkClientToken)
+		return errors.Errorf("environment variable %s not defined", splunkClientToken)
 	}
 	return nil
 }
@@ -166,7 +166,7 @@ func buildSplunkLogger(name string, client *http.Client, info SplunkConnectionIn
 func MakeSplunkLogger(name string) (Sender, error) {
 	info := GetSplunkConnectionInfo()
 	if err := info.validateFromEnv(); err != nil {
-		return nil, errors.WithStack(err)
+		return nil, errors.Wrap(err, "validating Splunk environment variables")
 	}
 
 	return NewSplunkLogger(name, info, LevelInfo{level.Trace, level.Trace})
@@ -177,7 +177,7 @@ func MakeSplunkLogger(name string) (Sender, error) {
 func MakeSplunkLoggerWithClient(name string, client *http.Client) (Sender, error) {
 	info := GetSplunkConnectionInfo()
 	if err := info.validateFromEnv(); err != nil {
-		return nil, errors.WithStack(err)
+		return nil, errors.Wrap(err, "validating Splunk environment variables")
 	}
 
 	return NewSplunkLoggerWithClient(name, info, LevelInfo{level.Trace, level.Trace}, client)

--- a/send/syslog.go
+++ b/send/syslog.go
@@ -5,6 +5,7 @@ package send
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"log/syslog"
@@ -44,15 +45,13 @@ func MakeSysLogger(network, raddr string) Sender {
 
 		if s.logger != nil {
 			if err := s.logger.Close(); err != nil {
-				s.ErrorHandler()(err, message.NewErrorWrapMessage(level.Error, err,
-					"problem closing syslogger"))
+				s.ErrorHandler()(err, message.NewErrorWrapMessage(level.Error, err, "closing syslogger"))
 			}
 		}
 
 		w, err := syslog.Dial(network, raddr, syslog.LOG_DEBUG, s.Name())
 		if err != nil {
-			s.ErrorHandler()(err, message.NewErrorWrapMessage(level.Error, err,
-				"error restarting syslog [%s] for logger: %s", err.Error(), s.Name()))
+			s.ErrorHandler()(err, message.NewErrorWrapMessage(level.Error, err, "restarting syslog for logger '%s'", s.Name()))
 			return
 		}
 
@@ -111,7 +110,7 @@ func (s *syslogger) sendToSysLog(p level.Priority, message string) error {
 		return s.logger.Debug(message)
 	}
 
-	return fmt.Errorf("encountered error trying to send: {%s}. Possibly, priority related", message)
+	return errors.New("invalid priority")
 }
 
 func (s *syslogger) Flush(_ context.Context) error { return nil }

--- a/send/xmpp.go
+++ b/send/xmpp.go
@@ -9,6 +9,7 @@ import (
 
 	xmpp "github.com/mattn/go-xmpp"
 	"github.com/mongodb/grip/message"
+	"github.com/pkg/errors"
 )
 
 type xmppLogger struct {
@@ -176,8 +177,7 @@ func (c *xmppClientImpl) Create(info XMPPConnectionInfo) error {
 		client, err = xmpp.NewClientNoTLS(info.Hostname, info.Username, info.Password, false)
 		if err != nil {
 			errs = append(errs, err.Error())
-			return fmt.Errorf("cannot connect to server '%s', as '%s': %s",
-				info.Hostname, info.Username, strings.Join(errs, "; "))
+			return errors.Errorf("connecting to server '%s', as user '%s': %s", info.Hostname, info.Username, strings.Join(errs, "; "))
 		}
 	}
 


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-16501

Clean up noisy error messages and fix some weirdly formatted error messages. There's still a mix of `fmt.Errorf` and `errors.Errorf` in the code base, but I didn't make those consistent (although I could if we wanted to).