### PR TITLE
EVG-17479 Switch Bluele to slack-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.16
 
 require (
 	github.com/andygrunwald/go-jira v0.0.0-20170512141550-c8c6680f245f
-	github.com/bluele/slack v0.0.0-20180528010058-b4b4d354a079
 	github.com/coreos/go-systemd v0.0.0-20160607160209-6dc8b843c670
 	github.com/dghubble/oauth1 v0.7.1
 	github.com/fuyufjh/splunk-hec-go v0.3.4-0.20190414090710-10df423a9f36
@@ -22,5 +21,6 @@ require (
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/shirou/gopsutil/v3 v3.22.8
+	github.com/slack-go/slack v0.11.3
 	google.golang.org/appengine v1.6.7 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -35,8 +35,6 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/andygrunwald/go-jira v0.0.0-20170512141550-c8c6680f245f h1:gmcGCFYZhcEqmrkOz93gtD08WHZPyXATTD/3OfL0rHk=
 github.com/andygrunwald/go-jira v0.0.0-20170512141550-c8c6680f245f/go.mod h1:yNYQrX3nGSrVdcVsM2mWz2pm7tTeDtYfRyVEkc3VUiY=
-github.com/bluele/slack v0.0.0-20180528010058-b4b4d354a079 h1:dm7wU6Dyf+rVGryOAB8/J/I+pYT/9AdG8dstD3kdMWU=
-github.com/bluele/slack v0.0.0-20180528010058-b4b4d354a079/go.mod h1:W679Ri2W93VLD8cVpEY/zLH1ow4zhJcCyjzrKxfM3QM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
@@ -63,6 +61,8 @@ github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-ole/go-ole v1.2.6 h1:/Fpf6oFPoeFik9ty7siob0G6Ke8QvQEuVcuChpwXzpY=
 github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
+github.com/go-test/deep v1.0.4 h1:u2CU3YKy9I2pmu9pX0eq50wCgjfGIt539SqR7FbHiho=
+github.com/go-test/deep v1.0.4/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -99,6 +99,7 @@ github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
@@ -119,6 +120,8 @@ github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
+github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
+github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
@@ -146,8 +149,11 @@ github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/shirou/gopsutil/v3 v3.22.8 h1:a4s3hXogo5mE2PfdfJIonDbstO/P+9JszdfhAHSzD9Y=
 github.com/shirou/gopsutil/v3 v3.22.8/go.mod h1:s648gW4IywYzUfE/KjXxUsqrqx/T2xO5VqOXxONeRfI=
+github.com/slack-go/slack v0.11.3 h1:GN7revxEMax4amCc3El9a+9SGnjmBvSUobs0QnO6ZO8=
+github.com/slack-go/slack v0.11.3/go.mod h1:hlGi5oXA+Gt+yWTPP0plCdRKmjsDxecdHxYQdlMQKOw=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/message/slack_test.go
+++ b/message/slack_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/bluele/slack"
+	"github.com/slack-go/slack"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/send/slack.go
+++ b/send/slack.go
@@ -301,7 +301,7 @@ func (o *SlackOptions) produceMessage(m message.Composer) (string, slack.MsgOpti
 type slackClient interface {
 	Create(string)
 	AuthTest() (*slack.AuthTestResponse, error)
-	PostMessage(channelID string, options ...slack.MsgOption) (string, string, error)
+	PostMessage(channelID string, options ...slack.MsgOption) (respChannel string, timestamp string, err error)
 }
 
 type slackClientImpl struct {

--- a/send/slack.go
+++ b/send/slack.go
@@ -88,7 +88,7 @@ func (s *slackJournal) Send(m message.Composer) {
 				slack.MsgOptionAttachments(slackMsg.Attachments...)
 
 		} else {
-			msg, attachmentParam = s.opts.produceMessage(m)
+			msg, attachmentParam = s.opts.produceAttachment(m)
 		}
 
 		var params []slack.MsgOption
@@ -210,7 +210,7 @@ func (o *SlackOptions) Validate() error {
 	return nil
 }
 
-func (o *SlackOptions) produceMessage(m message.Composer) (string, slack.MsgOption) {
+func (o *SlackOptions) produceAttachment(m message.Composer) (string, slack.MsgOption) {
 	var msg string
 
 	o.mutex.RLock()

--- a/send/slack_mock_test.go
+++ b/send/slack_mock_test.go
@@ -3,7 +3,7 @@ package send
 import (
 	"errors"
 
-	"github.com/bluele/slack"
+	"github.com/slack-go/slack"
 )
 
 // implements the slackClient interface for use in tests.
@@ -12,25 +12,24 @@ type slackClientMock struct {
 	failSendingMessage bool
 	numSent            int
 	lastTarget         string
-	lastMsg            *slack.ChatPostMessageOpt
+	lastMsgOptions     *[]slack.MsgOption
 }
 
 func (c *slackClientMock) Create(_ string) {}
-func (c *slackClientMock) AuthTest() (*slack.AuthTestApiResponse, error) {
+func (c *slackClientMock) AuthTest() (*slack.AuthTestResponse, error) {
 	if c.failAuthTest {
 		return nil, errors.New("mock failed auth test")
 	}
 	return nil, nil
 }
 
-func (c *slackClientMock) ChatPostMessage(target, _ string, msg *slack.ChatPostMessageOpt) error {
+func (c *slackClientMock) PostMessage(channelID string, options ...slack.MsgOption) (string, string, error) {
 	if c.failSendingMessage {
-		return errors.New("mock failed auth test")
+		return "", "", errors.New("mock failed auth test")
 	}
 
 	c.numSent++
-	c.lastTarget = target
-	c.lastMsg = msg
-
-	return nil
+	c.lastTarget = channelID
+	c.lastMsgOptions = &options
+	return "", "", nil
 }

--- a/send/slack_test.go
+++ b/send/slack_test.go
@@ -115,12 +115,12 @@ func (s *SlackSuite) TestFieldShouldIncludIsAlwaysTrueWhenFieldSetIsNile() {
 	}
 }
 
-func (s *SlackSuite) TestProduceMessage() {
+func (s *SlackSuite) TestProduceAttachment() {
 	opts := &SlackOptions{}
 	s.False(opts.Fields)
 	s.False(opts.BasicMetadata)
 
-	msg, attachment := opts.produceMessage(message.NewString("foo"))
+	msg, attachment := opts.produceAttachment(message.NewString("foo"))
 	s.NotNil(attachment)
 	s.Equal("foo", msg)
 


### PR DESCRIPTION
This rewrites message/slack.go to use [slack-go/slack](https://github.com/slack-go/slack) instead of the deprecated [bluele/slack](https://github.com/bluele/slack).

Tested on slack sandbox
