### PR TITLE
EVG-19137: Use HTTP retry client and check response status code in GitHub senders

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.1
 	github.com/trivago/tgo v1.0.7
-	golang.org/x/oauth2 v0.0.0-20211005180243-6b3c2da341f1
 )
 
 require (

--- a/send/error_handler.go
+++ b/send/error_handler.go
@@ -17,8 +17,7 @@ func ErrorHandlerFromLogger(l *log.Logger) ErrorHandler {
 			return
 		}
 
-		l.Println("logging error:", err.Error())
-		l.Println(m.String())
+		l.Println("logging error:", err.Error(), "\n", m.String())
 	}
 }
 

--- a/send/github.go
+++ b/send/github.go
@@ -76,7 +76,7 @@ func (s *githubLogger) Send(m message.Composer) {
 		if _, resp, err := s.gh.Create(ctx, s.opts.Account, s.opts.Repo, issue); err != nil {
 			s.ErrorHandler()(errors.Wrap(err, "sending GitHub Create API request"), m)
 		} else if resp.Response.StatusCode != http.StatusOK {
-			s.ErrorHandler()(errors.Errorf("recieved HTTP status '%d' from the Github Create API", resp.Response.StatusCode), m)
+			s.ErrorHandler()(errors.Errorf("received HTTP status '%d' from the Github Create API", resp.Response.StatusCode), m)
 		}
 	}
 }

--- a/send/github.go
+++ b/send/github.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/http"
 	"os"
+	"time"
 
+	"github.com/evergreen-ci/utility"
 	"github.com/google/go-github/github"
 	"github.com/mongodb/grip/message"
-	"golang.org/x/oauth2"
+	"github.com/pkg/errors"
 )
 
 type githubLogger struct {
@@ -36,8 +39,7 @@ func NewGithubIssuesLogger(name string, opts *GithubOptions) (Sender, error) {
 		gh:   &githubClientImpl{},
 	}
 
-	ctx := context.TODO()
-	s.gh.Init(ctx, opts.Token)
+	s.gh.Init(opts.Token)
 
 	fallback := log.New(os.Stdout, "", log.LstdFlags)
 	if err := s.SetErrorHandler(ErrorHandlerFromLogger(fallback)); err != nil {
@@ -69,9 +71,12 @@ func (s *githubLogger) Send(m message.Composer) {
 			Body:  &text,
 		}
 
-		ctx := context.TODO()
-		if _, _, err := s.gh.Create(ctx, s.opts.Account, s.opts.Repo, issue); err != nil {
-			s.ErrorHandler()(err, m)
+		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+		defer cancel()
+		if _, resp, err := s.gh.Create(ctx, s.opts.Account, s.opts.Repo, issue); err != nil {
+			s.ErrorHandler()(errors.Wrap(err, "sending GitHub Create API request"), m)
+		} else if resp.Response.StatusCode != http.StatusOK {
+			s.ErrorHandler()(errors.Errorf("recieved HTTP status '%d' from the Github Create API", resp.Response.StatusCode), m)
 		}
 	}
 }
@@ -85,7 +90,7 @@ func (s *githubLogger) Flush(_ context.Context) error { return nil }
 //////////////////////////////////////////////////////////////////////////
 
 type githubClient interface {
-	Init(context.Context, string)
+	Init(string)
 	// Issues
 	Create(context.Context, string, string, *github.IssueRequest) (*github.Issue, *github.Response, error)
 	CreateComment(context.Context, string, string, int, *github.IssueComment) (*github.IssueComment, *github.Response, error)
@@ -99,13 +104,8 @@ type githubClientImpl struct {
 	repos *github.RepositoriesService
 }
 
-func (c *githubClientImpl) Init(ctx context.Context, token string) {
-	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
-
-	tc := oauth2.NewClient(ctx, ts)
-
-	client := github.NewClient(tc)
-
+func (c *githubClientImpl) Init(token string) {
+	client := github.NewClient(utility.GetOauth2DefaultHTTPRetryableClient(token))
 	c.IssuesService = client.Issues
 	c.repos = client.Repositories
 }

--- a/send/github_comment.go
+++ b/send/github_comment.go
@@ -69,7 +69,7 @@ func (s *githubCommentLogger) Send(m message.Composer) {
 		if _, resp, err := s.gh.CreateComment(ctx, s.opts.Account, s.opts.Repo, s.issue, comment); err != nil {
 			s.ErrorHandler()(errors.Wrap(err, "sending GitHub CreateComment API request"), m)
 		} else if resp.Response.StatusCode != http.StatusOK {
-			s.ErrorHandler()(errors.Errorf("recieved HTTP status '%d' from the Github CreateComment API", resp.Response.StatusCode), m)
+			s.ErrorHandler()(errors.Errorf("received HTTP status '%d' from the Github CreateComment API", resp.Response.StatusCode), m)
 		}
 	}
 }

--- a/send/github_comment.go
+++ b/send/github_comment.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/http"
 	"os"
+	"time"
 
 	"github.com/google/go-github/github"
 	"github.com/mongodb/grip/message"
+	"github.com/pkg/errors"
 )
 
 type githubCommentLogger struct {
@@ -32,9 +35,7 @@ func NewGithubCommentLogger(name string, issueID int, opts *GithubOptions) (Send
 		gh:    &githubClientImpl{},
 	}
 
-	ctx := context.TODO()
-
-	s.gh.Init(ctx, opts.Token)
+	s.gh.Init(opts.Token)
 
 	fallback := log.New(os.Stdout, "", log.LstdFlags)
 	if err := s.SetErrorHandler(ErrorHandlerFromLogger(fallback)); err != nil {
@@ -63,10 +64,12 @@ func (s *githubCommentLogger) Send(m message.Composer) {
 
 		comment := &github.IssueComment{Body: &text}
 
-		ctx := context.TODO()
-		_, _, err = s.gh.CreateComment(ctx, s.opts.Account, s.opts.Repo, s.issue, comment)
-		if err != nil {
-			s.ErrorHandler()(err, m)
+		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+		defer cancel()
+		if _, resp, err := s.gh.CreateComment(ctx, s.opts.Account, s.opts.Repo, s.issue, comment); err != nil {
+			s.ErrorHandler()(errors.Wrap(err, "sending GitHub CreateComment API request"), m)
+		} else if resp.Response.StatusCode != http.StatusOK {
+			s.ErrorHandler()(errors.Errorf("recieved HTTP status '%d' from the Github CreateComment API", resp.Response.StatusCode), m)
 		}
 	}
 }

--- a/send/github_status.go
+++ b/send/github_status.go
@@ -2,15 +2,15 @@ package send
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log"
+	"net/http"
 	"os"
 	"time"
 
-	"github.com/evergreen-ci/utility"
 	"github.com/google/go-github/github"
 	"github.com/mongodb/grip/message"
+	"github.com/pkg/errors"
 )
 
 var (
@@ -68,20 +68,12 @@ func (s *githubStatusMessageLogger) Send(m message.Composer) {
 			return
 		}
 
-		err := utility.Retry(
-			context.TODO(),
-			func() (bool, error) {
-				_, _, err := s.gh.CreateStatus(context.TODO(), owner, repo, ref, status)
-				if err != nil {
-					return true, err
-				}
-				return false, nil
-			}, utility.RetryOptions{
-				MaxAttempts: numGithubAttempts,
-				MinDelay:    githubRetryMinDelay,
-			})
-		if err != nil {
-			s.ErrorHandler()(err, m)
+		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+		defer cancel()
+		if _, resp, err := s.gh.CreateStatus(ctx, owner, repo, ref, status); err != nil {
+			s.ErrorHandler()(errors.Wrap(err, "sending GitHub CreateStatus API request"), m)
+		} else if resp.Response.StatusCode != http.StatusOK {
+			s.ErrorHandler()(errors.Errorf("recieved HTTP status '%d' from the GitHub CreateStatus API", resp.Response.StatusCode), m)
 		}
 	}
 }
@@ -97,8 +89,7 @@ func NewGithubStatusLogger(name string, opts *GithubOptions, ref string) (Sender
 		ref:  ref,
 	}
 
-	ctx := context.TODO()
-	s.gh.Init(ctx, opts.Token)
+	s.gh.Init(opts.Token)
 
 	fallback := log.New(os.Stdout, "", log.LstdFlags)
 	if err := s.SetErrorHandler(ErrorHandlerFromLogger(fallback)); err != nil {

--- a/send/github_status.go
+++ b/send/github_status.go
@@ -73,7 +73,7 @@ func (s *githubStatusMessageLogger) Send(m message.Composer) {
 		if _, resp, err := s.gh.CreateStatus(ctx, owner, repo, ref, status); err != nil {
 			s.ErrorHandler()(errors.Wrap(err, "sending GitHub CreateStatus API request"), m)
 		} else if resp.Response.StatusCode != http.StatusOK {
-			s.ErrorHandler()(errors.Errorf("recieved HTTP status '%d' from the GitHub CreateStatus API", resp.Response.StatusCode), m)
+			s.ErrorHandler()(errors.Errorf("received HTTP status '%d' from the GitHub CreateStatus API", resp.Response.StatusCode), m)
 		}
 	}
 }

--- a/send/send_test.go
+++ b/send/send_test.go
@@ -362,7 +362,7 @@ func (s *SenderSuite) TestGithubIssuesLogger() {
 			},
 			m: message.NewString("hi"),
 			eh: func(err error, _ message.Composer) {
-				s.Contains(err.Error(), "recieved HTTP status")
+				s.Contains(err.Error(), "received HTTP status")
 			},
 			numSent: 1,
 		},
@@ -431,7 +431,7 @@ func (s *SenderSuite) TestGithubStatusLogger() {
 			},
 			m: message.NewGithubStatusMessage(level.Info, "example", message.GithubStatePending, "https://example.com/hi", "description"),
 			eh: func(err error, _ message.Composer) {
-				s.Contains(err.Error(), "recieved HTTP status")
+				s.Contains(err.Error(), "received HTTP status")
 			},
 			numSent: 1,
 		},
@@ -524,7 +524,7 @@ func (s *SenderSuite) TestGithubCommentLogger() {
 			},
 			m: message.NewString("hi"),
 			eh: func(err error, _ message.Composer) {
-				s.Contains(err.Error(), "recieved HTTP status")
+				s.Contains(err.Error(), "received HTTP status")
 			},
 			numSent: 1,
 		},


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-19137

This improves error handling and logging for the github senders to help us diagnose issues in prod:
- Use context with timeouts instead of TODO when calling the GitHub API.
- Use HTTP retry client instead of wrapping with the retry func.
- Check HTTP status code in resp and error if not 200.