### PR TITLE
EVG-18980 Add additional options for GitHub client

### DIFF
--- a/send/github.go
+++ b/send/github.go
@@ -49,7 +49,7 @@ type GithubOptions struct {
 	MinDelay    time.Duration
 }
 
-func (o *GithubOptions) Validate() {
+func (o *GithubOptions) populate() {
 	if o.MaxAttempts <= 0 {
 		o.MaxAttempts = numGithubAttempts
 	}
@@ -67,7 +67,7 @@ func (o *GithubOptions) Validate() {
 // NewGithubIssuesLogger builds a sender implementation that creates a
 // new issue in a Github Project for each log message.
 func NewGithubIssuesLogger(name string, opts *GithubOptions) (Sender, error) {
-	opts.Validate()
+	opts.populate()
 	s := &githubLogger{
 		Base: NewBase(name),
 		opts: opts,

--- a/send/github.go
+++ b/send/github.go
@@ -42,21 +42,39 @@ type githubLogger struct {
 // repository, used in the GithubIssuesLogger and the
 // GithubCommentLogger Sender implementations.
 type GithubOptions struct {
-	Account string
-	Repo    string
-	Token   string
+	Account     string
+	Repo        string
+	Token       string
+	MaxAttempts int
+	MinDelay    time.Duration
+}
+
+func (o *GithubOptions) Validate() {
+	if o.MaxAttempts <= 0 {
+		o.MaxAttempts = numGithubAttempts
+	}
+
+	if o.MinDelay <= 0 {
+		o.MinDelay = githubRetryMinDelay
+	}
+
+	const floor = 100 * time.Millisecond
+	if o.MinDelay < floor {
+		o.MinDelay = floor
+	}
 }
 
 // NewGithubIssuesLogger builds a sender implementation that creates a
 // new issue in a Github Project for each log message.
 func NewGithubIssuesLogger(name string, opts *GithubOptions) (Sender, error) {
+	opts.Validate()
 	s := &githubLogger{
 		Base: NewBase(name),
 		opts: opts,
 		gh:   &githubClientImpl{},
 	}
 
-	s.gh.Init(opts.Token)
+	s.gh.Init(opts.Token, opts.MaxAttempts, opts.MinDelay)
 
 	fallback := log.New(os.Stdout, "", log.LstdFlags)
 	if err := s.SetErrorHandler(ErrorHandlerFromLogger(fallback)); err != nil {
@@ -121,7 +139,7 @@ func (s *githubLogger) Flush(_ context.Context) error { return nil }
 //////////////////////////////////////////////////////////////////////////
 
 type githubClient interface {
-	Init(string)
+	Init(token string, maxAttempts int, minDelay time.Duration)
 	// Issues
 	Create(context.Context, string, string, *github.IssueRequest) (*github.Issue, *github.Response, error)
 	CreateComment(context.Context, string, string, int, *github.IssueComment) (*github.IssueComment, *github.Response, error)
@@ -135,7 +153,7 @@ type githubClientImpl struct {
 	repos *github.RepositoriesService
 }
 
-func (c *githubClientImpl) Init(token string) {
+func (c *githubClientImpl) Init(token string, maxAttempts int, minDelay time.Duration) {
 	client := utility.GetHTTPClient()
 	client.Transport = otelhttp.NewTransport(client.Transport)
 
@@ -143,8 +161,8 @@ func (c *githubClientImpl) Init(token string) {
 		token,
 		githubShouldRetry(),
 		utility.RetryHTTPDelay(utility.RetryOptions{
-			MaxAttempts: numGithubAttempts,
-			MinDelay:    githubRetryMinDelay,
+			MaxAttempts: maxAttempts,
+			MinDelay:    minDelay,
 		}),
 		client)
 	githubClient := github.NewClient(client)

--- a/send/github_client_mock_test.go
+++ b/send/github_client_mock_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/google/go-github/v53/github"
 )
@@ -19,7 +20,7 @@ type githubClientMock struct {
 	lastRepo string
 }
 
-func (g *githubClientMock) Init(_ string) {}
+func (g *githubClientMock) Init(_ string, _ int, _ time.Duration) {}
 
 func (g *githubClientMock) Create(_ context.Context, _ string, _ string, _ *github.IssueRequest) (*github.Issue, *github.Response, error) {
 	if g.failSend {

--- a/send/github_comment.go
+++ b/send/github_comment.go
@@ -30,7 +30,7 @@ type githubCommentLogger struct {
 // Specify the credentials to use the GitHub via the GithubOptions
 // structure, and the issue number as an argument to the constructor.
 func NewGithubCommentLogger(name string, issueID int, opts *GithubOptions) (Sender, error) {
-	opts.Validate()
+	opts.populate()
 	s := &githubCommentLogger{
 		Base:  NewBase(name),
 		opts:  opts,

--- a/send/github_comment.go
+++ b/send/github_comment.go
@@ -30,6 +30,7 @@ type githubCommentLogger struct {
 // Specify the credentials to use the GitHub via the GithubOptions
 // structure, and the issue number as an argument to the constructor.
 func NewGithubCommentLogger(name string, issueID int, opts *GithubOptions) (Sender, error) {
+	opts.Validate()
 	s := &githubCommentLogger{
 		Base:  NewBase(name),
 		opts:  opts,
@@ -37,7 +38,7 @@ func NewGithubCommentLogger(name string, issueID int, opts *GithubOptions) (Send
 		gh:    &githubClientImpl{},
 	}
 
-	s.gh.Init(opts.Token)
+	s.gh.Init(opts.Token, opts.MaxAttempts, opts.MinDelay)
 
 	fallback := log.New(os.Stdout, "", log.LstdFlags)
 	if err := s.SetErrorHandler(ErrorHandlerFromLogger(fallback)); err != nil {

--- a/send/github_status.go
+++ b/send/github_status.go
@@ -95,13 +95,14 @@ func (s *githubStatusMessageLogger) Flush(_ context.Context) error { return nil 
 // NewGithubStatusLogger returns a Sender to send payloads to the Github Status
 // API. Statuses will be attached to the given ref.
 func NewGithubStatusLogger(name string, opts *GithubOptions, ref string) (Sender, error) {
+	opts.Validate()
 	s := &githubStatusMessageLogger{
 		Base: NewBase(name),
 		gh:   &githubClientImpl{},
 		ref:  ref,
 	}
 
-	s.gh.Init(opts.Token)
+	s.gh.Init(opts.Token, opts.MaxAttempts, opts.MinDelay)
 
 	fallback := log.New(os.Stdout, "", log.LstdFlags)
 	if err := s.SetErrorHandler(ErrorHandlerFromLogger(fallback)); err != nil {

--- a/send/github_status.go
+++ b/send/github_status.go
@@ -95,7 +95,7 @@ func (s *githubStatusMessageLogger) Flush(_ context.Context) error { return nil 
 // NewGithubStatusLogger returns a Sender to send payloads to the Github Status
 // API. Statuses will be attached to the given ref.
 func NewGithubStatusLogger(name string, opts *GithubOptions, ref string) (Sender, error) {
-	opts.Validate()
+	opts.populate()
 	s := &githubStatusMessageLogger{
 		Base: NewBase(name),
 		gh:   &githubClientImpl{},


### PR DESCRIPTION
[EVG-18980](https://jira.mongodb.org/browse/EVG-18980) 

This adds the option to pass your own max attempts and min delay when creating a github client (which is used then when creating the github comment, status, and issue loggers).