### PR TITLE
DEVPROD-16299: allow personal access token in Jira validation

### DIFF
--- a/send/jira.go
+++ b/send/jira.go
@@ -141,6 +141,13 @@ func (o *JiraOptions) Validate() error {
 		return errors.New("Jira options cannot be nil")
 	}
 
+	basicAuthPopulated := o.BasicAuthOpts.Username != ""
+	oauth1Populated := o.Oauth1Opts.AccessToken != ""
+	personalAccessTokenPopulated := o.PersonalAccessTokenOpts.Token != ""
+	if !basicAuthPopulated && !oauth1Populated && !personalAccessTokenPopulated {
+		return errors.New("must specify at least one method of authentication")
+	}
+
 	var errs []string
 
 	if o.Name == "" {
@@ -149,10 +156,6 @@ func (o *JiraOptions) Validate() error {
 
 	if o.BaseURL == "" {
 		errs = append(errs, "no base URL specified")
-	}
-
-	if (o.BasicAuthOpts.Username == "") == (o.Oauth1Opts.AccessToken == "") {
-		return errors.New("must specify exactly 1 method of authentication")
 	}
 
 	if o.client == nil {

--- a/send/jira_test.go
+++ b/send/jira_test.go
@@ -2,7 +2,6 @@ package send
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"testing"
 
@@ -35,14 +34,14 @@ func (j *JiraSuite) SetupTest() {
 }
 
 func (j *JiraSuite) TestMockSenderWithNewConstructor() {
-	sender, err := NewJiraLogger(context.Background(), j.opts, LevelInfo{level.Trace, level.Info})
+	sender, err := NewJiraLogger(j.T().Context(), j.opts, LevelInfo{level.Trace, level.Info})
 	j.NotNil(sender)
 	j.NoError(err)
 }
 
 func (j *JiraSuite) TestConstructorMustCreate() {
 	j.opts.client = &jiraClientMock{failCreate: true}
-	sender, err := NewJiraLogger(context.Background(), j.opts, LevelInfo{level.Trace, level.Info})
+	sender, err := NewJiraLogger(j.T().Context(), j.opts, LevelInfo{level.Trace, level.Info})
 
 	j.Nil(sender)
 	j.Error(err)
@@ -50,39 +49,34 @@ func (j *JiraSuite) TestConstructorMustCreate() {
 
 func (j *JiraSuite) TestConstructorMustPassAuthTest() {
 	j.opts.client = &jiraClientMock{failAuth: true}
-	sender, err := NewJiraLogger(context.Background(), j.opts, LevelInfo{level.Trace, level.Info})
+	sender, err := NewJiraLogger(j.T().Context(), j.opts, LevelInfo{level.Trace, level.Info})
 
 	j.Nil(sender)
 	j.Error(err)
 }
 
 func (j *JiraSuite) TestConstructorErrorsWithInvalidConfigs() {
-	sender, err := NewJiraLogger(context.Background(), nil, LevelInfo{level.Trace, level.Info})
+	sender, err := NewJiraLogger(j.T().Context(), nil, LevelInfo{level.Trace, level.Info})
 
 	j.Nil(sender)
 	j.Error(err)
 
-	sender, err = NewJiraLogger(context.Background(), &JiraOptions{}, LevelInfo{level.Trace, level.Info})
+	sender, err = NewJiraLogger(j.T().Context(), &JiraOptions{}, LevelInfo{level.Trace, level.Info})
 	j.Nil(sender)
 	j.Error(err)
 
 	opts := &JiraOptions{
-		BasicAuthOpts: JiraBasicAuth{
-			Username: "foo",
-			Password: "bar",
-		},
-		Oauth1Opts: JiraOauth1{
-			AccessToken: "12345",
-		},
+		Name:    "jira",
+		BaseURL: "url",
 	}
 
-	sender, err = NewJiraLogger(context.Background(), opts, LevelInfo{level.Trace, level.Info})
+	sender, err = NewJiraLogger(j.T().Context(), opts, LevelInfo{level.Trace, level.Info})
 	j.Nil(sender)
-	j.EqualError(err, "must specify exactly 1 method of authentication")
+	j.EqualError(err, "must specify at least one method of authentication")
 }
 
 func (j *JiraSuite) TestSendMethod() {
-	sender, err := NewJiraLogger(context.Background(), j.opts, LevelInfo{level.Trace, level.Info})
+	sender, err := NewJiraLogger(j.T().Context(), j.opts, LevelInfo{level.Trace, level.Info})
 	j.NotNil(sender)
 	j.NoError(err)
 
@@ -104,7 +98,7 @@ func (j *JiraSuite) TestSendMethod() {
 }
 
 func (j *JiraSuite) TestSendMethodWithError() {
-	sender, err := NewJiraLogger(context.Background(), j.opts, LevelInfo{level.Trace, level.Info})
+	sender, err := NewJiraLogger(j.T().Context(), j.opts, LevelInfo{level.Trace, level.Info})
 	j.NotNil(sender)
 	j.NoError(err)
 
@@ -184,7 +178,7 @@ func (j *JiraSuite) TestGetFieldsWithFields() {
 }
 
 func (j *JiraSuite) TestTruncate() {
-	sender, err := NewJiraLogger(context.Background(), j.opts, LevelInfo{level.Trace, level.Info})
+	sender, err := NewJiraLogger(j.T().Context(), j.opts, LevelInfo{level.Trace, level.Info})
 	j.NotNil(sender)
 	j.NoError(err)
 
@@ -219,7 +213,7 @@ func (j *JiraSuite) TestTruncate() {
 }
 
 func (j *JiraSuite) TestCustomFields() {
-	sender, err := NewJiraLogger(context.Background(), j.opts, LevelInfo{level.Trace, level.Info})
+	sender, err := NewJiraLogger(j.T().Context(), j.opts, LevelInfo{level.Trace, level.Info})
 	j.NotNil(sender)
 	j.NoError(err)
 
@@ -250,7 +244,7 @@ func (j *JiraSuite) TestCustomFields() {
 }
 
 func (j *JiraSuite) TestPopulateKey() {
-	sender, err := NewJiraLogger(context.Background(), j.opts, LevelInfo{level.Trace, level.Info})
+	sender, err := NewJiraLogger(j.T().Context(), j.opts, LevelInfo{level.Trace, level.Info})
 	j.NotNil(sender)
 	j.NoError(err)
 	mock, ok := j.opts.client.(*jiraClientMock)
@@ -285,7 +279,7 @@ func (j *JiraSuite) TestPopulateKey() {
 }
 
 func (j *JiraSuite) TestWhenCallbackNil() {
-	sender, err := NewJiraLogger(context.Background(), j.opts, LevelInfo{level.Trace, level.Info})
+	sender, err := NewJiraLogger(j.T().Context(), j.opts, LevelInfo{level.Trace, level.Info})
 	j.NotNil(sender)
 	j.NoError(err)
 	mock, ok := j.opts.client.(*jiraClientMock)


### PR DESCRIPTION
[DEVPROD-16299](https://jira.mongodb.org/browse/DEVPROD-16299)

Update Jira validation to allow just a personal access token to be set. The other two methods of authentication are not used.