### PR TITLE
DEVPROD-5810: retry for GitHub connection reset

### DIFF
--- a/send/github.go
+++ b/send/github.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/evergreen-ci/utility"
@@ -175,6 +176,12 @@ func githubShouldRetry() utility.HTTPRetryFunction {
 		trace.SpanFromContext(req.Context()).SetAttributes(attribute.Int(githubRetriesAttribute, index))
 
 		if err != nil {
+			if strings.Contains(err.Error(), "connection reset by peer") {
+				// This has happened in the past when GitHub was having an
+				// outage, so it's worth retrying.
+				return true
+			}
+
 			return utility.IsTemporaryError(err)
 		}
 


### PR DESCRIPTION
DEVPROD-5810

Copied the same retry logic from [here](https://github.com/evergreen-ci/evergreen/blob/941a96c305e0058c532c4126568ba9f9f274abb0/model/githubapp/github_app_installation.go#L172-L176).