### PR TITLE
DEVPROD-16306 Remove old Jira auth methods

### DIFF
--- a/send/jira_comment.go
+++ b/send/jira_comment.go
@@ -42,13 +42,6 @@ func NewJiraCommentLogger(ctx context.Context, id string, opts *JiraOptions, l L
 	}
 
 	authOpts := jiraAuthOpts{
-		username:            opts.BasicAuthOpts.Username,
-		password:            opts.BasicAuthOpts.Password,
-		addBasicAuthHeader:  opts.BasicAuthOpts.UseBasicAuth,
-		accessToken:         opts.Oauth1Opts.AccessToken,
-		tokenSecret:         opts.Oauth1Opts.TokenSecret,
-		privateKey:          opts.Oauth1Opts.PrivateKey,
-		consumerKey:         opts.Oauth1Opts.ConsumerKey,
 		personalAccessToken: opts.PersonalAccessTokenOpts.Token,
 	}
 	if err := j.opts.client.Authenticate(ctx, authOpts); err != nil {

--- a/send/jira_comment_test.go
+++ b/send/jira_comment_test.go
@@ -21,9 +21,8 @@ func TestJiraCommentSuite(t *testing.T) {
 func (j *JiraCommentSuite) SetupTest() {
 	j.opts = &JiraOptions{
 		BaseURL: "url",
-		BasicAuthOpts: JiraBasicAuth{
-			Username: "username",
-			Password: "password",
+		PersonalAccessTokenOpts: JiraPersonalAccessTokenAuth{
+			Token: "token",
 		},
 		client: &jiraClientMock{},
 		Name:   "1234",

--- a/send/jira_test.go
+++ b/send/jira_test.go
@@ -71,7 +71,7 @@ func (j *JiraSuite) TestConstructorErrorsWithInvalidConfigs() {
 
 	sender, err = NewJiraLogger(j.T().Context(), opts, LevelInfo{level.Trace, level.Info})
 	j.Nil(sender)
-	j.EqualError(err, "must specify at least one method of authentication")
+	j.EqualError(err, "must specify personal access token for Jira authentication")
 }
 
 func (j *JiraSuite) TestSendMethod() {

--- a/send/jira_test.go
+++ b/send/jira_test.go
@@ -25,9 +25,8 @@ func (j *JiraSuite) SetupTest() {
 	j.opts = &JiraOptions{
 		Name:    "bot",
 		BaseURL: "url",
-		BasicAuthOpts: JiraBasicAuth{
-			Username: "username",
-			Password: "password",
+		PersonalAccessTokenOpts: JiraPersonalAccessTokenAuth{
+			Token: "token",
 		},
 		client: &jiraClientMock{},
 	}


### PR DESCRIPTION
[DEVPROD-16306](https://jira.mongodb.org/browse/DEVPROD-16306)

### Description
This removes the old two Jira authentication methods. I kept the authentication logic that we have in case they switch to a new one (if this switch to personal access tokens is any indication).

### Tests
I updated the tests to have a personal access token (dummy). Existing unit tests